### PR TITLE
fix: commit deployed contract addresses for Vercel build

### DIFF
--- a/artifacts/deployed-addresses.json
+++ b/artifacts/deployed-addresses.json
@@ -1,0 +1,7 @@
+{
+  "JurorRegistry": "0xDDA350601bd34192dC1869Cb537Ae550841F4F6F",
+  "TrustLedger": "0x1b6bBb43a81EE89D924362FDa92aaD991a8A0AFc",
+  "Arbitration": "0xE3B13b233Abf2091323C300deBbb64940Eb7E184",
+  "network": "sepolia",
+  "deployedAt": "2026-05-19T00:27:49.923Z"
+}


### PR DESCRIPTION
artifacts/deployed-addresses.json was gitignored, causing Vercel to build with the zero address fallback. Adding it directly so the frontend resolves the correct Sepolia TrustLedger address at build time.