### PR TITLE
feat(wallet): Reown AppKit — Safari fix + Coinbase, Phantom, Tangem support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,10 +94,13 @@ FORK_URL=
 # Omit (or set to 0) to fork from the latest block.
 FORK_BLOCK_NUMBER=
 
-# ─── Frontend (Next.js / WalletConnect) [REQUIRED for frontend] ───────────────
+# ─── Frontend (Next.js / Reown AppKit + WalletConnect) [REQUIRED for frontend] ─
 # Not secret - ends up visible in the browser bundle.
-# Get a free project ID at https://cloud.walletconnect.com
-# Create a project (type: App), copy the Project ID from the dashboard.
+# Powers the Reown AppKit connect modal (src/lib/wagmi.ts). Without it the modal
+# cannot pair over the WalletConnect relay, so QR / mobile flows (MetaMask,
+# Phantom, Tangem, WalletConnect) fail; only injected and Coinbase remain usable.
+# Get a free project ID at https://dashboard.reown.com (formerly
+# cloud.walletconnect.com): create a project (type: AppKit), copy the Project ID.
 NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=
 
 # ─── Frontend base path [OPTIONAL] ───────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ payouts.
 | TypeScript types               | TypeChain (ethers-v6)                                                                        |
 | Chain                          | Ethereum Sepolia (testnet)                                                                   |
 | Off-chain storage              | IPFS via Pinata (with optional Arweave)                                                      |
-| Wallet                         | MetaMask + RainbowKit                                                                        |
-| Frontend                       | Next.js 16, React 19, wagmi v2, RainbowKit, viem                                             |
+| Wallet                         | Reown AppKit — Coinbase, MetaMask, Phantom, Tangem, WalletConnect, and injected wallets      |
+| Frontend                       | Next.js 16, React 19, wagmi v2, Reown AppKit, viem                                           |
 | Backend (planned)              | Node.js, TypeScript, SQL                                                                     |
 | Randomness                     | Chainlink VRF v2                                                                             |
 | Price feed                     | Chainlink AggregatorV3 (ETH/USD)                                                             |
@@ -1256,8 +1256,9 @@ TrustLedger/
 │   │   ├── globals.css                           # Tailwind v4 base styles + font vars
 │   │   └── favicon.ico
 │   ├── components/
-│   │   ├── Navbar.tsx                            # Sticky nav with RainbowKit connect button
-│   │   ├── Providers.tsx                         # WagmiProvider + RainbowKitProvider + QueryClientProvider
+│   │   ├── ConnectButton.tsx                     # Wallet connect button (opens the Reown AppKit modal)
+│   │   ├── Navbar.tsx                            # Sticky nav with the wallet connect button
+│   │   ├── Providers.tsx                         # WagmiProvider + QueryClientProvider + AppKit theme sync
 │   │   └── ThemeToggle.tsx                       # Light/dark mode toggle button
 │   ├── lib/
 │   │   ├── abi.ts                                # TrustLedger / Arbitration / JurorRegistry / ReputationRegistry ABIs

--- a/TODO.md
+++ b/TODO.md
@@ -198,8 +198,25 @@ mainnet launch deliverables.
 
 ## Phase 3 — Wallet and Browser Compatibility
 
-- [ ] Fix Base (works on Safari), Browser Wallet, MetaMask, and WalletConnect
-      integration and compatibility, since they cause issues on Safari.
+- [x] Fix Base (works on Safari), Browser Wallet, MetaMask, and WalletConnect
+      integration and compatibility, since they cause issues on Safari. —
+      Replaced RainbowKit with **Reown AppKit** (`@reown/appkit` +
+      `@reown/appkit-adapter-wagmi`) in `src/lib/wagmi.ts`, which fixes Safari's
+      two failure modes (broken `metamask://` deep links and a WalletConnect
+      relay that errored against RainbowKit's placeholder project ID) and
+      removes the deprecated RainbowKit Coinbase connector. The connect modal
+      now features Coinbase Wallet (no longer deprecated), MetaMask, Phantom,
+      and Tangem by their verified WalletConnect-registry IDs, plus the Base
+      Account passkey smart wallet and every other registry/injected wallet. A
+      custom `src/components/ConnectButton.tsx` (AppKit
+      `useAppKit`/`useAppKitAccount` hooks) replaces RainbowKit's
+      `<ConnectButton>` across the navbar and all six pages; `Providers.tsx`
+      drops `RainbowKitProvider` and syncs AppKit's light/dark theme with
+      `next-themes`. The relay-dependent wallets still require
+      `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` (documented in `.env.example`);
+      injected and Coinbase work without it. `tsc`, ESLint, Prettier, and
+      `next build` all pass; real-device QA on iOS Safari is still recommended
+      before mainnet.
     - Resolve these issues for compatibility across all browsers and wallets,
       but prioritize Safari, since it is the most common browser on iOS and has
       the most wallet-integration problems. This ensures the platform is
@@ -216,9 +233,9 @@ mainnet launch deliverables.
       styling pipeline and adopt it consistently if it improves maintainability
       over the current approach, otherwise document why it is intentionally
       unused.
-    - Performance: trim client bundle size, lazy-load wallet/RainbowKit code,
-      adopt Next.js streaming/Server Components where possible, optimize fonts
-      and images, and target strong Core Web Vitals (LCP, CLS, INP).
+    - Performance: trim client bundle size, lazy-load wallet/AppKit code, adopt
+      Next.js streaming/Server Components where possible, optimize fonts and
+      images, and target strong Core Web Vitals (LCP, CLS, INP).
     - Security: add a strict Content-Security-Policy and security headers, audit
       `dangerouslySetInnerHTML`/external links, keep dependencies patched, and
       ensure no secrets reach the client bundle.

--- a/docs/MISCELLANEOUS.md
+++ b/docs/MISCELLANEOUS.md
@@ -109,7 +109,7 @@ checks. Both toolchains share `solc 0.8.24` and `optimizer_runs = 200`.
 - **Affected:** All versions of `ws` before 8.17.1 allow a remote attacker to
   cause a DoS by sending a specially crafted HTTP request.
 - **Fix:** Both `package.json` and `src/package.json` pin `ws` to `8.20.1` via
-  npm `overrides`. This forces every transitive dependent (RainbowKit, wagmi,
+  npm `overrides`. This forces every transitive dependent (Reown AppKit, wagmi,
   Hardhat) to resolve to the patched version.
 - **Status:** Suppressed. `npm audit` exits clean.
 

--- a/docs/PRESENTATION.md
+++ b/docs/PRESENTATION.md
@@ -448,7 +448,7 @@ Step 12  Execute ruling (funds released; minority jurors slashed if applicable)
 | Solidity testing    | Foundry (`forge test`)                    | Native Solidity, fast, 10k fuzz runs per suite                |
 | TS testing          | Hardhat 2.x + Mocha + Chai + ethers.js v6 | Full integration tests with TypeChain types                   |
 | TypeScript          | TypeScript 6 / Node.js 22+                | Strict types, ESM + CJS dual config                           |
-| Frontend            | Next.js 16 + RainbowKit + wagmi + viem    | Wallet connection, dashboard, juror portal, reputation lookup |
+| Frontend            | Next.js 16 + Reown AppKit + wagmi + viem  | Wallet connection, dashboard, juror portal, reputation lookup |
 | CI/CD               | GitHub Actions                            | Lint, compile, test on every pull request                     |
 | Code review         | CodeRabbit                                | AI-assisted PR review with Solidity awareness                 |
 
@@ -651,7 +651,7 @@ workflow.
 | 4        | Chainlink VRF v2 subscription (funded + consumer) | Needs sub ID                                   |
 | 5        | External security audit                           | Not started                                    |
 | 6        | Formal verification (Certora / Echidna)           | Not started                                    |
-| 7        | Frontend (Next.js + RainbowKit + wagmi)           | In progress (`/reputation`, dashboard ratings) |
+| 7        | Frontend (Next.js + Reown AppKit + wagmi)         | In progress (`/reputation`, dashboard ratings) |
 | 8        | IPFS upload service                               | Planned                                        |
 | 9        | Gas optimization pass                             | Not started                                    |
 | 10       | Emergency pause / kill switch                     | Not started                                    |

--- a/src/README.md
+++ b/src/README.md
@@ -87,7 +87,7 @@ npm install
 ```
 
 `npm install` reads `src/package.json` and downloads all the frontend
-dependencies (Next.js, wagmi, RainbowKit, Tailwind CSS, etc.) into a local
+dependencies (Next.js, wagmi, Reown AppKit, Tailwind CSS, etc.) into a local
 `node_modules/` folder. This takes about 30-60 seconds. You should see a summary
 like `added 754 packages` when it finishes.
 
@@ -286,8 +286,9 @@ src/
 │   └── favicon.ico
 │
 ├── components/
-│   ├── Navbar.tsx                    # Sticky top nav with RainbowKit ConnectButton
-│   ├── Providers.tsx                 # WagmiProvider + RainbowKitProvider + QueryClientProvider
+│   ├── ConnectButton.tsx            # Wallet connect button (opens the Reown AppKit modal)
+│   ├── Navbar.tsx                    # Sticky top nav with the wallet connect button
+│   ├── Providers.tsx                 # WagmiProvider + QueryClientProvider + AppKit theme sync
 │   └── ThemeToggle.tsx               # Light/dark mode toggle button
 │
 ├── lib/
@@ -328,11 +329,12 @@ src/
 
 ### Components - `components/`
 
-| File              | Description                                                                                     |
-| ----------------- | ----------------------------------------------------------------------------------------------- |
-| `Navbar.tsx`      | Sticky navigation bar with the RainbowKit `ConnectButton` and page links                        |
-| `Providers.tsx`   | Tree of `WagmiProvider`, `QueryClientProvider`, and `RainbowKitProvider` - wraps the entire app |
-| `ThemeToggle.tsx` | Light/dark mode toggle button; reads and writes the `theme` class on `<html>`                   |
+| File                | Description                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------ |
+| `ConnectButton.tsx` | Wallet connect button; opens the Reown AppKit modal (Coinbase, MetaMask, Phantom, Tangem, …)     |
+| `Navbar.tsx`        | Sticky navigation bar with the wallet `ConnectButton` and page links                             |
+| `Providers.tsx`     | Tree of `WagmiProvider` and `QueryClientProvider`, plus AppKit theme sync - wraps the entire app |
+| `ThemeToggle.tsx`   | Light/dark mode toggle button; reads and writes the `theme` class on `<html>`                    |
 
 ### Library - `lib/`
 
@@ -370,14 +372,17 @@ no runtime fetch needed.
 
 ## wagmi Integration
 
-**App setup with RainbowKit** (`src/components/Providers.tsx`):
+**App setup with Reown AppKit** (`src/components/Providers.tsx`):
+
+The AppKit modal is created once as an import side effect in `@/lib/wagmi`
+(`createAppKit({ ... })`), so the provider tree only needs wagmi and React
+Query. The modal itself is a web component injected into `document.body` — no
+extra provider wraps the children.
 
 ```tsx
-import { RainbowKitProvider, darkTheme } from "@rainbow-me/rainbowkit";
 import { WagmiProvider } from "wagmi";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
-import { config } from "@/lib/wagmi";
-import "@rainbow-me/rainbowkit/styles.css";
+import { config } from "@/lib/wagmi"; // importing this runs createAppKit()
 
 export function Providers({ children }: { children: React.ReactNode }) {
     const [queryClient] = useState(() => new QueryClient());
@@ -385,11 +390,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     return (
         <WagmiProvider config={config}>
             <QueryClientProvider client={queryClient}>
-                <RainbowKitProvider
-                    theme={darkTheme({ accentColor: "#6366f1" })}
-                >
-                    {children}
-                </RainbowKitProvider>
+                {children}
             </QueryClientProvider>
         </WagmiProvider>
     );

--- a/src/app/arbitration/[id]/page.tsx
+++ b/src/app/arbitration/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useParams } from "next/navigation";
 import { useAccount, useReadContract, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { ConnectButton } from "@/components/ConnectButton";
 import { encodePacked, formatEther, keccak256 } from "viem";
 import { ARBITRATION_ABI } from "@/lib/abi";
 import { ARBITRATION_ADDRESS } from "@/lib/wagmi";

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -8,7 +8,7 @@ import {
 	useSimulateContract,
 	useWaitForTransactionReceipt,
 } from "wagmi";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { ConnectButton } from "@/components/ConnectButton";
 import { parseEther, keccak256, toBytes, parseEventLogs } from "viem";
 import { TRUSTLEDGER_ABI } from "@/lib/abi";
 import { TRUSTLEDGER_ADDRESS, getExplorerTxUrl } from "@/lib/wagmi";

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useAccount, useReadContract, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { ConnectButton } from "@/components/ConnectButton";
 import { formatEther, keccak256, toBytes } from "viem";
 import { TRUSTLEDGER_ABI, STATUS_LABELS } from "@/lib/abi";
 import { REPUTATION_REGISTRY_ADDRESS, TRUSTLEDGER_ADDRESS } from "@/lib/wagmi";

--- a/src/app/freelancer/accept/page.tsx
+++ b/src/app/freelancer/accept/page.tsx
@@ -10,7 +10,7 @@ import {
 	useWaitForTransactionReceipt,
 	useSignMessage,
 } from "wagmi";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { ConnectButton } from "@/components/ConnectButton";
 import { keccak256, encodePacked, parseSignature } from "viem";
 import { TRUSTLEDGER_ABI, STATUS_LABELS } from "@/lib/abi";
 import { TRUSTLEDGER_ADDRESS, getExplorerTxUrl } from "@/lib/wagmi";

--- a/src/app/juror/page.tsx
+++ b/src/app/juror/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useAccount, useReadContract, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { ConnectButton } from "@/components/ConnectButton";
 import { formatEther, parseEther } from "viem";
 import { JUROR_REGISTRY_ABI } from "@/lib/abi";
 import { JUROR_REGISTRY_ADDRESS } from "@/lib/wagmi";

--- a/src/app/reputation/page.tsx
+++ b/src/app/reputation/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useAccount, useChainId, usePublicClient, useReadContract } from "wagmi";
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { ConnectButton } from "@/components/ConnectButton";
 import { isAddress, parseAbiItem } from "viem";
 import { REPUTATION_REGISTRY_ABI } from "@/lib/abi";
 import { REPUTATION_REGISTRY_ADDRESS, TRUSTLEDGER_ADDRESS } from "@/lib/wagmi";

--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useAppKit, useAppKitAccount } from "@reown/appkit/react";
+
+/**
+ * App-wide wallet connect button backed by Reown AppKit.
+ *
+ * Renders "Connect Wallet" when disconnected and a truncated address when
+ * connected; clicking opens the AppKit modal (account + network management when
+ * connected, wallet picker otherwise). Replaces RainbowKit's `<ConnectButton>`.
+ */
+export function ConnectButton(): React.JSX.Element {
+	const { open } = useAppKit();
+	const { address, isConnected } = useAppKitAccount();
+
+	const label =
+		isConnected && address !== undefined
+			? `${address.slice(0, 6)}…${address.slice(-4)}`
+			: "Connect Wallet";
+
+	return (
+		<button
+			type="button"
+			onClick={() => {
+				void open();
+			}}
+			className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+		>
+			{label}
+		</button>
+	);
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { ConnectButton } from "@/components/ConnectButton";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -80,7 +80,7 @@ export function Navbar(): React.JSX.Element {
 						</a>
 					)}
 					<ThemeToggle />
-					<ConnectButton chainStatus="icon" showBalance={false} />
+					<ConnectButton />
 				</div>
 			</div>
 		</header>

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,23 +1,27 @@
 "use client";
 
-import { RainbowKitProvider, darkTheme, lightTheme } from "@rainbow-me/rainbowkit";
+import { useAppKitTheme } from "@reown/appkit/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider, useTheme } from "next-themes";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { WagmiProvider } from "wagmi";
 import { config } from "@/lib/wagmi";
-import "@rainbow-me/rainbowkit/styles.css";
 
-const ACCENT = "#6366f1";
-
-/** Reads resolved theme and passes matching RainbowKit theme down. */
-function RainbowKitThemeWrapper({ children }: { children: React.ReactNode }): React.JSX.Element {
+/**
+ * Keeps the AppKit modal's light/dark mode in sync with next-themes.
+ *
+ * AppKit is a singleton (created in `@/lib/wagmi`), so this renders nothing and
+ * only pushes the resolved theme into AppKit whenever it changes.
+ */
+function AppKitThemeSync(): null {
 	const { resolvedTheme } = useTheme();
-	const rkTheme =
-		resolvedTheme === "light"
-			? lightTheme({ accentColor: ACCENT })
-			: darkTheme({ accentColor: ACCENT });
-	return <RainbowKitProvider theme={rkTheme}>{children}</RainbowKitProvider>;
+	const { setThemeMode } = useAppKitTheme();
+
+	useEffect(() => {
+		setThemeMode(resolvedTheme === "light" ? "light" : "dark");
+	}, [resolvedTheme, setThemeMode]);
+
+	return null;
 }
 
 export function Providers({ children }: { children: React.ReactNode }): React.JSX.Element {
@@ -32,7 +36,8 @@ export function Providers({ children }: { children: React.ReactNode }): React.JS
 		>
 			<WagmiProvider config={config}>
 				<QueryClientProvider client={queryClient}>
-					<RainbowKitThemeWrapper>{children}</RainbowKitThemeWrapper>
+					<AppKitThemeSync />
+					{children}
 				</QueryClientProvider>
 			</WagmiProvider>
 		</ThemeProvider>

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -1,11 +1,6 @@
-import { getDefaultConfig } from "@rainbow-me/rainbowkit";
-import {
-	base,
-	injectedWallet,
-	metaMaskWallet,
-	walletConnectWallet,
-} from "@rainbow-me/rainbowkit/wallets";
-import { arbitrum, base as baseChain, optimism, sepolia } from "wagmi/chains";
+import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
+import { arbitrum, type AppKitNetwork, base, optimism, sepolia } from "@reown/appkit/networks";
+import { createAppKit, type CreateAppKit } from "@reown/appkit/react";
 
 export const TRUSTLEDGER_ADDRESS: `0x${string}` =
 	(process.env["NEXT_PUBLIC_TRUSTLEDGER_ADDRESS"] as `0x${string}` | undefined) ??
@@ -27,30 +22,82 @@ const wcProjectId = process.env["NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID"];
 
 const hasWcProjectId = wcProjectId !== undefined && wcProjectId !== "";
 
-export const config = getDefaultConfig({
-	appName: "TrustLedger",
-	projectId: hasWcProjectId ? wcProjectId : "YOUR_PROJECT_ID",
-	wallets: [
-		{
-			groupName: "Popular",
-			wallets: [
-				// Only shown when a browser extension (e.g. MetaMask) is already injected.
-				// Avoids the Safari "This page couldn't load" error caused by the metamask:// deep link
-				// that fires when the extension is absent.
-				injectedWallet,
-				// Explicit MetaMask entry — shows a QR code fallback when the extension is missing,
-				// which is the correct path for Safari + MetaMask Mobile.
-				metaMaskWallet,
-				// Universal QR-code connection; works in every browser including Safari.
-				...(hasWcProjectId ? [walletConnectWallet] : []),
-				base,
-			],
-		},
-	],
-	// Sepolia: testing and development only.
-	// Arbitrum / Base / Optimism: production L2s with gas costs proportional to typical contract values.
-	chains: [sepolia, arbitrum, baseChain, optimism],
+// Reown AppKit (and the WalletConnect relay it builds on) require a real project
+// ID. The placeholder keeps the build and local dev working; set
+// NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID for the connect modal to actually pair.
+const projectId = hasWcProjectId ? wcProjectId : "YOUR_PROJECT_ID";
+
+// Sepolia: testing and development only.
+// Arbitrum / Base / Optimism: production L2s with gas costs proportional to typical contract values.
+const networks: [AppKitNetwork, ...AppKitNetwork[]] = [sepolia, arbitrum, base, optimism];
+
+// Brand accent shared with the rest of the UI (indigo-500).
+const ACCENT_COLOR = "#6366f1";
+
+// Origin advertised to wallets during pairing. Falls back to the production URL
+// during SSR/build where `window` is undefined.
+const appUrl =
+	process.env["NEXT_PUBLIC_SITE_URL"] ??
+	(typeof window !== "undefined" ? window.location.origin : "https://trustledger.vercel.app");
+
+// Verified WalletConnect Explorer IDs, surfaced first in the connect modal.
+// These are the wallets we explicitly support; AppKit still lists every other
+// registry wallet under "All Wallets".
+const FEATURED_WALLET_IDS = [
+	"d0ca99ff52b99abc48743dad0f7fc891e041be73574f7fac4afe5d4bb83845c8", // Coinbase Wallet
+	"c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96", // MetaMask
+	"a797aa35c0fadbfc1a53e7f675162ed5226968b44a19ee3d24385c64d1d3c393", // Phantom
+	"21030f20fba1a77115858ee3a8bc5841c739ab4537441316e2f4b1d0a8d218af", // Tangem
+	"fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa", // Base Account
+];
+
+// The wagmi adapter builds the wagmi config AppKit drives. `ssr: true` mirrors
+// the previous getDefaultConfig setup so Next.js server rendering stays correct.
+const wagmiAdapter = new WagmiAdapter({
+	networks,
+	projectId,
 	ssr: true,
+});
+
+/**
+ * The wagmi config consumed by `<WagmiProvider>`. Built by the Reown AppKit
+ * wagmi adapter rather than RainbowKit's getDefaultConfig, so the connect modal
+ * can offer Coinbase Wallet (no longer deprecated), MetaMask, WalletConnect,
+ * Phantom, Tangem, and every other WalletConnect-registry wallet.
+ */
+export const config = wagmiAdapter.wagmiConfig;
+
+/**
+ * The AppKit modal singleton. Created here (as an import side effect) so the
+ * `<appkit-*>` web components register and the AppKit React hooks work anywhere
+ * the wagmi config is imported. WalletConnect-relay wallets (MetaMask QR,
+ * Phantom, Tangem, WalletConnect) need a real projectId; injected/Coinbase work
+ * without the relay, which keeps desktop and iOS Safari connections reliable.
+ */
+export const appkit = createAppKit({
+	// AppKit types an adapter's `namespace` as optional, but the adapters array
+	// requires it; under `exactOptionalPropertyTypes` that surfaces as a mismatch.
+	// The wagmi adapter is a valid ChainAdapter, so assert the expected element type.
+	adapters: [wagmiAdapter] as NonNullable<CreateAppKit["adapters"]>,
+	networks,
+	projectId,
+	metadata: {
+		name: "TrustLedger",
+		description:
+			"Decentralized freelance escrow with on-chain reputation and juror arbitration.",
+		url: appUrl,
+		icons: [`${appUrl}/logo.png`],
+	},
+	featuredWalletIds: FEATURED_WALLET_IDS,
+	themeMode: "dark",
+	themeVariables: {
+		"--w3m-accent": ACCENT_COLOR,
+	},
+	features: {
+		analytics: false,
+		email: false,
+		socials: false,
+	},
 });
 
 const EXPLORERS: Record<number, string> = {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@rainbow-me/rainbowkit": "^2.2.11",
+				"@reown/appkit": "^1.8.20",
+				"@reown/appkit-adapter-wagmi": "^1.8.20",
 				"@tanstack/react-query": "^5.100.10",
 				"arweave": "^1.15.7",
 				"next": "16.2.6",
@@ -1387,6 +1388,21 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/@coinbase/cdp-sdk/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/@coinbase/cdp-sdk/node_modules/zod": {
 			"version": "3.25.76",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -1520,12 +1536,6 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
-		},
-		"node_modules/@emotion/hash": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-			"license": "MIT"
 		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.9.1",
@@ -1894,9 +1904,6 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1912,9 +1919,6 @@
 			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1932,9 +1936,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1950,9 +1951,6 @@
 			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
 			"cpu": [
 				"riscv64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1970,9 +1968,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1988,9 +1983,6 @@
 			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -2008,9 +2000,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2027,9 +2016,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -2045,9 +2031,6 @@
 			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
 			"cpu": [
 				"arm"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2071,9 +2054,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2095,9 +2075,6 @@
 			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
 			"cpu": [
 				"ppc64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2121,9 +2098,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2145,9 +2119,6 @@
 			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2171,9 +2142,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2196,9 +2164,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2220,9 +2185,6 @@
 			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -2370,6 +2332,16 @@
 			"resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
 			"integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@lit/react": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+			"integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peerDependencies": {
+				"@types/react": "17 || 18 || 19"
+			}
 		},
 		"node_modules/@lit/reactive-element": {
 			"version": "2.1.2",
@@ -2903,6 +2875,15 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@msgpack/msgpack": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+			"integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -2977,9 +2958,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2995,9 +2973,6 @@
 			"integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3015,9 +2990,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3033,9 +3005,6 @@
 			"integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3175,147 +3144,393 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/@rainbow-me/rainbowkit": {
-			"version": "2.2.11",
-			"resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-2.2.11.tgz",
-			"integrity": "sha512-FHPsRHMBpuHHhuyKktAR13O9agmsUUunDnVEP4hG1dSZ2JojXLUSWyLG28VbGIJakHYylkNguiLFnqM/BM8ERA==",
+		"node_modules/@phosphor-icons/webcomponents": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@phosphor-icons/webcomponents/-/webcomponents-2.1.5.tgz",
+			"integrity": "sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@vanilla-extract/css": "1.20.1",
-				"@vanilla-extract/dynamic": "2.1.5",
-				"@vanilla-extract/sprinkles": "1.6.5",
-				"clsx": "2.1.1",
-				"cuer": "0.0.3",
-				"react-remove-scroll": "2.7.2",
-				"ua-parser-js": "^2.0.9"
-			},
-			"engines": {
-				"node": ">=12.4"
-			},
-			"peerDependencies": {
-				"@tanstack/react-query": ">=5.0.0",
-				"react": ">=18",
-				"react-dom": ">=18",
-				"viem": "2.x",
-				"wagmi": "^2.9.0"
+				"lit": "^3"
 			}
 		},
 		"node_modules/@reown/appkit": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.8.tgz",
-			"integrity": "sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==",
-			"license": "Apache-2.0",
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.20.tgz",
+			"integrity": "sha512-+OI1TWg3XcMRhZ5RGVF0+AjkUvTPpODP6HFIgmxsV8HCf6bfE+jaYYE+JJcaz05TYJJ2TCXSYDyRfRvjSUzMzg==",
+			"hasInstallScript": true,
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@reown/appkit-common": "1.7.8",
-				"@reown/appkit-controllers": "1.7.8",
-				"@reown/appkit-pay": "1.7.8",
-				"@reown/appkit-polyfills": "1.7.8",
-				"@reown/appkit-scaffold-ui": "1.7.8",
-				"@reown/appkit-ui": "1.7.8",
-				"@reown/appkit-utils": "1.7.8",
-				"@reown/appkit-wallet": "1.7.8",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/universal-provider": "2.21.0",
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-controllers": "1.8.20",
+				"@reown/appkit-pay": "1.8.20",
+				"@reown/appkit-polyfills": "1.8.20",
+				"@reown/appkit-scaffold-ui": "1.8.20",
+				"@reown/appkit-ui": "1.8.20",
+				"@reown/appkit-utils": "1.8.20",
+				"@reown/appkit-wallet": "1.8.20",
+				"@walletconnect/universal-provider": "2.23.7",
 				"bs58": "6.0.0",
-				"valtio": "1.13.2",
-				"viem": ">=2.29.0"
+				"semver": "7.7.2",
+				"valtio": "2.1.7",
+				"viem": ">=2.45.0"
+			},
+			"optionalDependencies": {
+				"@lit/react": "1.0.8"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi": {
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.8.20.tgz",
+			"integrity": "sha512-HVCOyYrW5NYjj2BtdAaOabrC7q2GkdpsQ9KviwD+dvZhBu0rM0/SdD36WbLVTjezJLKS2/3/WfKbl5rdqvKpZw==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@reown/appkit": "1.8.20",
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-controllers": "1.8.20",
+				"@reown/appkit-polyfills": "1.8.20",
+				"@reown/appkit-scaffold-ui": "1.8.20",
+				"@reown/appkit-utils": "1.8.20",
+				"@reown/appkit-wallet": "1.8.20",
+				"@walletconnect/universal-provider": "2.23.7",
+				"valtio": "2.1.7"
+			},
+			"optionalDependencies": {
+				"@wagmi/connectors": ">=5.9.9"
+			},
+			"peerDependencies": {
+				"@wagmi/core": ">=2.21.2",
+				"viem": ">=2.45.0",
+				"wagmi": ">=2.19.5"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/@noble/curves": {
+			"version": "1.9.7",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+			"integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "1.8.0"
+			},
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/core": {
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+			"integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-provider": "1.0.14",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/jsonrpc-ws-connection": "1.0.16",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/relay-api": "1.0.11",
+				"@walletconnect/relay-auth": "1.1.0",
+				"@walletconnect/safe-json": "1.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
+				"@walletconnect/window-getters": "1.0.1",
+				"es-toolkit": "1.44.0",
+				"events": "3.3.0",
+				"uint8arrays": "3.1.1"
+			},
+			"engines": {
+				"node": ">=18.20.8"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/logger": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+			"integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+			"license": "MIT",
+			"dependencies": {
+				"@walletconnect/safe-json": "^1.0.2",
+				"pino": "10.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/sign-client": {
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+			"integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@walletconnect/core": "2.23.7",
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/types": {
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+			"integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "3.0.2",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/universal-provider": {
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+			"integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/jsonrpc-http-connection": "1.0.8",
+				"@walletconnect/jsonrpc-provider": "1.0.14",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/sign-client": "2.23.7",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
+				"es-toolkit": "1.44.0",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/utils": {
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+			"integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@msgpack/msgpack": "3.1.3",
+				"@noble/ciphers": "1.3.0",
+				"@noble/curves": "1.9.7",
+				"@noble/hashes": "1.8.0",
+				"@scure/base": "1.2.6",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/relay-api": "1.0.11",
+				"@walletconnect/relay-auth": "1.1.0",
+				"@walletconnect/safe-json": "1.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/window-getters": "1.0.1",
+				"@walletconnect/window-metadata": "1.0.1",
+				"blakejs": "1.2.1",
+				"detect-browser": "5.3.0",
+				"ox": "0.9.3",
+				"uint8arrays": "3.1.1"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/es-toolkit": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+			"integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/on-exit-leak-free": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/ox": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+			"integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@adraffy/ens-normalize": "^1.11.0",
+				"@noble/ciphers": "^1.3.0",
+				"@noble/curves": "1.9.1",
+				"@noble/hashes": "^1.8.0",
+				"@scure/bip32": "^1.7.0",
+				"@scure/bip39": "^1.6.0",
+				"abitype": "^1.0.9",
+				"eventemitter3": "5.0.1"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.4.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/ox/node_modules/@noble/curves": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+			"integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "1.8.0"
+			},
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/pino": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+			"integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^2.0.0",
+				"pino-std-serializers": "^7.0.0",
+				"process-warning": "^5.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"slow-redact": "^0.3.0",
+				"sonic-boom": "^4.0.1",
+				"thread-stream": "^3.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/pino-abstract-transport": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+			"integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/pino-std-serializers": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/process-warning": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/sonic-boom": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/thread-stream": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+			"integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+			"license": "MIT",
+			"dependencies": {
+				"real-require": "^0.2.0"
+			}
+		},
+		"node_modules/@reown/appkit-adapter-wagmi/node_modules/uint8arrays": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+			"license": "MIT",
+			"dependencies": {
+				"multiformats": "^9.4.2"
 			}
 		},
 		"node_modules/@reown/appkit-common": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.8.tgz",
-			"integrity": "sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ==",
-			"license": "Apache-2.0",
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.20.tgz",
+			"integrity": "sha512-x6Yc8FaZZaEnsRCu6crYD/s1MA+Ffk35rJNZpug8I26iAJgi+o3rar/0lwZ70dl/QA9ytnwFUFWzhXqkT3O7Og==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"big.js": "6.2.2",
 				"dayjs": "1.11.13",
-				"viem": ">=2.29.0"
+				"viem": ">=2.45.0"
 			}
 		},
 		"node_modules/@reown/appkit-controllers": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.8.tgz",
-			"integrity": "sha512-IdXlJlivrlj6m63VsGLsjtPHHsTWvKGVzWIP1fXZHVqmK+rZCBDjCi9j267Rb9/nYRGHWBtlFQhO8dK35WfeDA==",
-			"license": "Apache-2.0",
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.20.tgz",
+			"integrity": "sha512-2Gdi/ScftfBK3MwfAJcf/bGRByHgHzaAK8rCzKrYYUqLjbRFR9I/uq7gd6D+w4Xm+NRCpdiKFJY/0zPSfq+gpw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@reown/appkit-common": "1.7.8",
-				"@reown/appkit-wallet": "1.7.8",
-				"@walletconnect/universal-provider": "2.21.0",
-				"valtio": "1.13.2",
-				"viem": ">=2.29.0"
-			}
-		},
-		"node_modules/@reown/appkit-controllers/node_modules/@noble/ciphers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
-			"integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-wallet": "1.8.20",
+				"@walletconnect/universal-provider": "2.23.7",
+				"valtio": "2.1.7",
+				"viem": ">=2.45.0"
 			}
 		},
 		"node_modules/@reown/appkit-controllers/node_modules/@noble/curves": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-			"integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+			"version": "1.9.7",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+			"integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
 			"license": "MIT",
 			"dependencies": {
-				"@noble/hashes": "1.7.1"
+				"@noble/hashes": "1.8.0"
 			},
 			"engines": {
 				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit-controllers/node_modules/@noble/hashes": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-			"integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit-controllers/node_modules/@scure/bip32": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-			"integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/curves": "~1.8.1",
-				"@noble/hashes": "~1.7.1",
-				"@scure/base": "~1.2.2"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit-controllers/node_modules/@scure/bip39": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-			"integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/hashes": "~1.7.1",
-				"@scure/base": "~1.2.4"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.0.tgz",
-			"integrity": "sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+			"integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-provider": "1.0.14",
@@ -3323,60 +3538,68 @@
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/jsonrpc-ws-connection": "1.0.16",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
 				"@walletconnect/window-getters": "1.0.1",
-				"es-toolkit": "1.33.0",
+				"es-toolkit": "1.44.0",
 				"events": "3.3.0",
-				"uint8arrays": "3.1.0"
+				"uint8arrays": "3.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=18.20.8"
+			}
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/@walletconnect/logger": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+			"integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+			"license": "MIT",
+			"dependencies": {
+				"@walletconnect/safe-json": "^1.0.2",
+				"pino": "10.0.0"
 			}
 		},
 		"node_modules/@reown/appkit-controllers/node_modules/@walletconnect/sign-client": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
-			"integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
-			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+			"integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@walletconnect/core": "2.21.0",
+				"@walletconnect/core": "2.23.7",
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit-controllers/node_modules/@walletconnect/types": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
-			"integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+			"integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-types": "1.0.4",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit-controllers/node_modules/@walletconnect/universal-provider": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
-			"integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
-			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+			"integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -3384,109 +3607,64 @@
 				"@walletconnect/jsonrpc-types": "1.0.4",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
-				"@walletconnect/sign-client": "2.21.0",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
-				"es-toolkit": "1.33.0",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/sign-client": "2.23.7",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
+				"es-toolkit": "1.44.0",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
-			"integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+			"integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@noble/ciphers": "1.2.1",
-				"@noble/curves": "1.8.1",
-				"@noble/hashes": "1.7.1",
+				"@msgpack/msgpack": "3.1.3",
+				"@noble/ciphers": "1.3.0",
+				"@noble/curves": "1.9.7",
+				"@noble/hashes": "1.8.0",
+				"@scure/base": "1.2.6",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
+				"@walletconnect/types": "2.23.7",
 				"@walletconnect/window-getters": "1.0.1",
 				"@walletconnect/window-metadata": "1.0.1",
-				"bs58": "6.0.0",
+				"blakejs": "1.2.1",
 				"detect-browser": "5.3.0",
-				"query-string": "7.1.3",
-				"uint8arrays": "3.1.0",
-				"viem": "2.23.2"
+				"ox": "0.9.3",
+				"uint8arrays": "3.1.1"
 			}
 		},
-		"node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils/node_modules/viem": {
-			"version": "2.23.2",
-			"resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
-			"integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
+		"node_modules/@reown/appkit-controllers/node_modules/es-toolkit": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+			"integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
 			"license": "MIT",
-			"dependencies": {
-				"@noble/curves": "1.8.1",
-				"@noble/hashes": "1.7.1",
-				"@scure/bip32": "1.6.2",
-				"@scure/bip39": "1.5.4",
-				"abitype": "1.0.8",
-				"isows": "1.0.6",
-				"ox": "0.6.7",
-				"ws": "8.18.0"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
 		},
-		"node_modules/@reown/appkit-controllers/node_modules/abitype": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-			"integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+		"node_modules/@reown/appkit-controllers/node_modules/on-exit-leak-free": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
 			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/wevm"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4",
-				"zod": "^3 >=3.22.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				},
-				"zod": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@reown/appkit-controllers/node_modules/isows": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-			"integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"ws": "*"
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@reown/appkit-controllers/node_modules/ox": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
-			"integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+			"integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
 			"funding": [
 				{
 					"type": "github",
@@ -3495,12 +3673,13 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@adraffy/ens-normalize": "^1.10.1",
-				"@noble/curves": "^1.6.0",
-				"@noble/hashes": "^1.5.0",
-				"@scure/bip32": "^1.5.0",
-				"@scure/bip39": "^1.4.0",
-				"abitype": "^1.0.6",
+				"@adraffy/ens-normalize": "^1.11.0",
+				"@noble/ciphers": "^1.3.0",
+				"@noble/curves": "1.9.1",
+				"@noble/hashes": "^1.8.0",
+				"@scure/bip32": "^1.7.0",
+				"@scure/bip39": "^1.6.0",
+				"abitype": "^1.0.9",
 				"eventemitter3": "5.0.1"
 			},
 			"peerDependencies": {
@@ -3512,146 +3691,208 @@
 				}
 			}
 		},
-		"node_modules/@reown/appkit-pay": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
-			"integrity": "sha512-OSGQ+QJkXx0FEEjlpQqIhT8zGJKOoHzVnyy/0QFrl3WrQTjCzg0L6+i91Ad5Iy1zb6V5JjqtfIFpRVRWN4M3pw==",
-			"license": "Apache-2.0",
+		"node_modules/@reown/appkit-controllers/node_modules/ox/node_modules/@noble/curves": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+			"integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+			"license": "MIT",
 			"dependencies": {
-				"@reown/appkit-common": "1.7.8",
-				"@reown/appkit-controllers": "1.7.8",
-				"@reown/appkit-ui": "1.7.8",
-				"@reown/appkit-utils": "1.7.8",
+				"@noble/hashes": "1.8.0"
+			},
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/pino": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+			"integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^2.0.0",
+				"pino-std-serializers": "^7.0.0",
+				"process-warning": "^5.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"slow-redact": "^0.3.0",
+				"sonic-boom": "^4.0.1",
+				"thread-stream": "^3.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/pino-abstract-transport": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+			"integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/pino-std-serializers": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/process-warning": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/sonic-boom": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/thread-stream": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+			"integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+			"license": "MIT",
+			"dependencies": {
+				"real-require": "^0.2.0"
+			}
+		},
+		"node_modules/@reown/appkit-controllers/node_modules/uint8arrays": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+			"license": "MIT",
+			"dependencies": {
+				"multiformats": "^9.4.2"
+			}
+		},
+		"node_modules/@reown/appkit-pay": {
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.20.tgz",
+			"integrity": "sha512-JEoTVetCWNFJnbkYGtwvdWa7ZW7xF0uOH+jmJvnAbYSXTR+Bd8HdQOMn/AoWulSu6qmjKjNpZQmNjkIUf5yiUw==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-controllers": "1.8.20",
+				"@reown/appkit-ui": "1.8.20",
+				"@reown/appkit-utils": "1.8.20",
 				"lit": "3.3.0",
-				"valtio": "1.13.2"
+				"valtio": "2.1.7"
 			}
 		},
 		"node_modules/@reown/appkit-polyfills": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.8.tgz",
-			"integrity": "sha512-W/kq786dcHHAuJ3IV2prRLEgD/2iOey4ueMHf1sIFjhhCGMynMkhsOhQMUH0tzodPqUgAC494z4bpIDYjwWXaA==",
-			"license": "Apache-2.0",
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.20.tgz",
+			"integrity": "sha512-88qJedSBYkhCZxeyODcQhqKt45OkS28VbZGNsay6t7FexvPcoibYMtkHaP79ojE8OuhV7k3FlrssrjPES3OFCw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"buffer": "6.0.3"
 			}
 		},
 		"node_modules/@reown/appkit-scaffold-ui": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.8.tgz",
-			"integrity": "sha512-RCeHhAwOrIgcvHwYlNWMcIDibdI91waaoEYBGw71inE0kDB8uZbE7tE6DAXJmDkvl0qPh+DqlC4QbJLF1FVYdQ==",
-			"license": "Apache-2.0",
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.20.tgz",
+			"integrity": "sha512-Vx0qib30UUbcKT8VeNcCcZkkhtaOT28TtClQ8nKC0EdOkLA08Lxt0j32XpEat2c4Fl6xzAIIOuZO7HRBTxMfzA==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@reown/appkit-common": "1.7.8",
-				"@reown/appkit-controllers": "1.7.8",
-				"@reown/appkit-ui": "1.7.8",
-				"@reown/appkit-utils": "1.7.8",
-				"@reown/appkit-wallet": "1.7.8",
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-controllers": "1.8.20",
+				"@reown/appkit-pay": "1.8.20",
+				"@reown/appkit-ui": "1.8.20",
+				"@reown/appkit-utils": "1.8.20",
+				"@reown/appkit-wallet": "1.8.20",
 				"lit": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit-ui": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.8.tgz",
-			"integrity": "sha512-1hjCKjf6FLMFzrulhl0Y9Vb9Fu4royE+SXCPSWh4VhZhWqlzUFc7kutnZKx8XZFVQH4pbBvY62SpRC93gqoHow==",
-			"license": "Apache-2.0",
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.20.tgz",
+			"integrity": "sha512-ObWhgu+4capnVhxtEG0VMRtGHwr6bso9VUcxDIfUDpjNAMi1HQBvXiBJ/R098Gvjmjz0QLwNe8YNVe50KaCTVw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@reown/appkit-common": "1.7.8",
-				"@reown/appkit-controllers": "1.7.8",
-				"@reown/appkit-wallet": "1.7.8",
+				"@phosphor-icons/webcomponents": "2.1.5",
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-controllers": "1.8.20",
+				"@reown/appkit-wallet": "1.8.20",
 				"lit": "3.3.0",
 				"qrcode": "1.5.3"
 			}
 		},
 		"node_modules/@reown/appkit-utils": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.8.tgz",
-			"integrity": "sha512-8X7UvmE8GiaoitCwNoB86pttHgQtzy4ryHZM9kQpvjQ0ULpiER44t1qpVLXNM4X35O0v18W0Dk60DnYRMH2WRw==",
-			"license": "Apache-2.0",
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.20.tgz",
+			"integrity": "sha512-ZVPUhZm/8TbR5MI1GzhazpUShrjVhZCC8Fyc7m+VXSPVZkPiW7K2AtTDAqhfYeStvBSJIvC6jbKwhlaWGR1TDQ==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@reown/appkit-common": "1.7.8",
-				"@reown/appkit-controllers": "1.7.8",
-				"@reown/appkit-polyfills": "1.7.8",
-				"@reown/appkit-wallet": "1.7.8",
-				"@walletconnect/logger": "2.1.2",
-				"@walletconnect/universal-provider": "2.21.0",
-				"valtio": "1.13.2",
-				"viem": ">=2.29.0"
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-controllers": "1.8.20",
+				"@reown/appkit-polyfills": "1.8.20",
+				"@reown/appkit-wallet": "1.8.20",
+				"@wallet-standard/wallet": "1.1.0",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/universal-provider": "2.23.7",
+				"valtio": "2.1.7",
+				"viem": ">=2.45.0"
+			},
+			"optionalDependencies": {
+				"@base-org/account": "2.4.0",
+				"@coinbase/wallet-sdk": "4.3.6",
+				"@safe-global/safe-apps-provider": "0.18.6",
+				"@safe-global/safe-apps-sdk": "9.1.0"
 			},
 			"peerDependencies": {
-				"valtio": "1.13.2"
-			}
-		},
-		"node_modules/@reown/appkit-utils/node_modules/@noble/ciphers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
-			"integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
+				"valtio": "2.1.7"
 			}
 		},
 		"node_modules/@reown/appkit-utils/node_modules/@noble/curves": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-			"integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+			"version": "1.9.7",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+			"integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
 			"license": "MIT",
 			"dependencies": {
-				"@noble/hashes": "1.7.1"
+				"@noble/hashes": "1.8.0"
 			},
 			"engines": {
 				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit-utils/node_modules/@noble/hashes": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-			"integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit-utils/node_modules/@scure/bip32": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-			"integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/curves": "~1.8.1",
-				"@noble/hashes": "~1.7.1",
-				"@scure/base": "~1.2.2"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit-utils/node_modules/@scure/bip39": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-			"integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/hashes": "~1.7.1",
-				"@scure/base": "~1.2.4"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.0.tgz",
-			"integrity": "sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+			"integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-provider": "1.0.14",
@@ -3659,60 +3900,68 @@
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/jsonrpc-ws-connection": "1.0.16",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
 				"@walletconnect/window-getters": "1.0.1",
-				"es-toolkit": "1.33.0",
+				"es-toolkit": "1.44.0",
 				"events": "3.3.0",
-				"uint8arrays": "3.1.0"
+				"uint8arrays": "3.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=18.20.8"
+			}
+		},
+		"node_modules/@reown/appkit-utils/node_modules/@walletconnect/logger": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+			"integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+			"license": "MIT",
+			"dependencies": {
+				"@walletconnect/safe-json": "^1.0.2",
+				"pino": "10.0.0"
 			}
 		},
 		"node_modules/@reown/appkit-utils/node_modules/@walletconnect/sign-client": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
-			"integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
-			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+			"integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@walletconnect/core": "2.21.0",
+				"@walletconnect/core": "2.23.7",
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit-utils/node_modules/@walletconnect/types": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
-			"integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+			"integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-types": "1.0.4",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit-utils/node_modules/@walletconnect/universal-provider": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
-			"integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
-			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+			"integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -3720,109 +3969,64 @@
 				"@walletconnect/jsonrpc-types": "1.0.4",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
-				"@walletconnect/sign-client": "2.21.0",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
-				"es-toolkit": "1.33.0",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/sign-client": "2.23.7",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
+				"es-toolkit": "1.44.0",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
-			"integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+			"integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@noble/ciphers": "1.2.1",
-				"@noble/curves": "1.8.1",
-				"@noble/hashes": "1.7.1",
+				"@msgpack/msgpack": "3.1.3",
+				"@noble/ciphers": "1.3.0",
+				"@noble/curves": "1.9.7",
+				"@noble/hashes": "1.8.0",
+				"@scure/base": "1.2.6",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
+				"@walletconnect/types": "2.23.7",
 				"@walletconnect/window-getters": "1.0.1",
 				"@walletconnect/window-metadata": "1.0.1",
-				"bs58": "6.0.0",
+				"blakejs": "1.2.1",
 				"detect-browser": "5.3.0",
-				"query-string": "7.1.3",
-				"uint8arrays": "3.1.0",
-				"viem": "2.23.2"
+				"ox": "0.9.3",
+				"uint8arrays": "3.1.1"
 			}
 		},
-		"node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils/node_modules/viem": {
-			"version": "2.23.2",
-			"resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
-			"integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
+		"node_modules/@reown/appkit-utils/node_modules/es-toolkit": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+			"integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
 			"license": "MIT",
-			"dependencies": {
-				"@noble/curves": "1.8.1",
-				"@noble/hashes": "1.7.1",
-				"@scure/bip32": "1.6.2",
-				"@scure/bip39": "1.5.4",
-				"abitype": "1.0.8",
-				"isows": "1.0.6",
-				"ox": "0.6.7",
-				"ws": "8.18.0"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
 		},
-		"node_modules/@reown/appkit-utils/node_modules/abitype": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-			"integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+		"node_modules/@reown/appkit-utils/node_modules/on-exit-leak-free": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
 			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/wevm"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4",
-				"zod": "^3 >=3.22.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				},
-				"zod": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@reown/appkit-utils/node_modules/isows": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-			"integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"ws": "*"
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@reown/appkit-utils/node_modules/ox": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
-			"integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+			"integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
 			"funding": [
 				{
 					"type": "github",
@@ -3831,12 +4035,13 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@adraffy/ens-normalize": "^1.10.1",
-				"@noble/curves": "^1.6.0",
-				"@noble/hashes": "^1.5.0",
-				"@scure/bip32": "^1.5.0",
-				"@scure/bip39": "^1.4.0",
-				"abitype": "^1.0.6",
+				"@adraffy/ens-normalize": "^1.11.0",
+				"@noble/ciphers": "^1.3.0",
+				"@noble/curves": "1.9.1",
+				"@noble/hashes": "^1.8.0",
+				"@scure/bip32": "^1.7.0",
+				"@scure/bip39": "^1.6.0",
+				"abitype": "^1.0.9",
 				"eventemitter3": "5.0.1"
 			},
 			"peerDependencies": {
@@ -3848,16 +4053,219 @@
 				}
 			}
 		},
-		"node_modules/@reown/appkit-wallet": {
-			"version": "1.7.8",
-			"resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
-			"integrity": "sha512-kspz32EwHIOT/eg/ZQbFPxgXq0B/olDOj3YMu7gvLEFz4xyOFd/wgzxxAXkp5LbG4Cp++s/elh79rVNmVFdB9A==",
-			"license": "Apache-2.0",
+		"node_modules/@reown/appkit-utils/node_modules/ox/node_modules/@noble/curves": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+			"integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+			"license": "MIT",
 			"dependencies": {
-				"@reown/appkit-common": "1.7.8",
-				"@reown/appkit-polyfills": "1.7.8",
-				"@walletconnect/logger": "2.1.2",
+				"@noble/hashes": "1.8.0"
+			},
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@reown/appkit-utils/node_modules/pino": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+			"integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^2.0.0",
+				"pino-std-serializers": "^7.0.0",
+				"process-warning": "^5.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"slow-redact": "^0.3.0",
+				"sonic-boom": "^4.0.1",
+				"thread-stream": "^3.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/@reown/appkit-utils/node_modules/pino-abstract-transport": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+			"integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-utils/node_modules/pino-std-serializers": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-utils/node_modules/process-warning": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-utils/node_modules/real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/@reown/appkit-utils/node_modules/sonic-boom": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-utils/node_modules/thread-stream": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+			"integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+			"license": "MIT",
+			"dependencies": {
+				"real-require": "^0.2.0"
+			}
+		},
+		"node_modules/@reown/appkit-utils/node_modules/uint8arrays": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+			"license": "MIT",
+			"dependencies": {
+				"multiformats": "^9.4.2"
+			}
+		},
+		"node_modules/@reown/appkit-wallet": {
+			"version": "1.8.20",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.20.tgz",
+			"integrity": "sha512-fEYnCQTQFSi8qtGfdQp7BHAVD8yiijPgjXhel0jFLKTX5leufGKjrERtnn2vABoUHQucwQzI+Q958Bnx/lHE2w==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@reown/appkit-common": "1.8.20",
+				"@reown/appkit-polyfills": "1.8.20",
+				"@walletconnect/logger": "3.0.2",
 				"zod": "3.22.4"
+			}
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/@walletconnect/logger": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+			"integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+			"license": "MIT",
+			"dependencies": {
+				"@walletconnect/safe-json": "^1.0.2",
+				"pino": "10.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/on-exit-leak-free": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/pino": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+			"integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^2.0.0",
+				"pino-std-serializers": "^7.0.0",
+				"process-warning": "^5.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"slow-redact": "^0.3.0",
+				"sonic-boom": "^4.0.1",
+				"thread-stream": "^3.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/pino-abstract-transport": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+			"integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/pino-std-serializers": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/process-warning": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/sonic-boom": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/@reown/appkit-wallet/node_modules/thread-stream": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+			"integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+			"license": "MIT",
+			"dependencies": {
+				"real-require": "^0.2.0"
 			}
 		},
 		"node_modules/@reown/appkit-wallet/node_modules/zod": {
@@ -3869,77 +4277,26 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
-		"node_modules/@reown/appkit/node_modules/@noble/ciphers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
-			"integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/@reown/appkit/node_modules/@noble/curves": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-			"integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+			"version": "1.9.7",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+			"integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
 			"license": "MIT",
 			"dependencies": {
-				"@noble/hashes": "1.7.1"
+				"@noble/hashes": "1.8.0"
 			},
 			"engines": {
 				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit/node_modules/@noble/hashes": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-			"integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit/node_modules/@scure/bip32": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-			"integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/curves": "~1.8.1",
-				"@noble/hashes": "~1.7.1",
-				"@scure/base": "~1.2.2"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@reown/appkit/node_modules/@scure/bip39": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-			"integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/hashes": "~1.7.1",
-				"@scure/base": "~1.2.4"
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@reown/appkit/node_modules/@walletconnect/core": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.0.tgz",
-			"integrity": "sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+			"integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-provider": "1.0.14",
@@ -3947,60 +4304,68 @@
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/jsonrpc-ws-connection": "1.0.16",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
 				"@walletconnect/window-getters": "1.0.1",
-				"es-toolkit": "1.33.0",
+				"es-toolkit": "1.44.0",
 				"events": "3.3.0",
-				"uint8arrays": "3.1.0"
+				"uint8arrays": "3.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=18.20.8"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/@walletconnect/logger": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+			"integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+			"license": "MIT",
+			"dependencies": {
+				"@walletconnect/safe-json": "^1.0.2",
+				"pino": "10.0.0"
 			}
 		},
 		"node_modules/@reown/appkit/node_modules/@walletconnect/sign-client": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
-			"integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
-			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+			"integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@walletconnect/core": "2.21.0",
+				"@walletconnect/core": "2.23.7",
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit/node_modules/@walletconnect/types": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
-			"integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+			"integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/heartbeat": "1.2.2",
 				"@walletconnect/jsonrpc-types": "1.0.4",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/logger": "3.0.2",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit/node_modules/@walletconnect/universal-provider": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
-			"integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
-			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+			"integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@walletconnect/events": "1.0.1",
 				"@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -4008,109 +4373,64 @@
 				"@walletconnect/jsonrpc-types": "1.0.4",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/keyvaluestorage": "1.1.1",
-				"@walletconnect/logger": "2.1.2",
-				"@walletconnect/sign-client": "2.21.0",
-				"@walletconnect/types": "2.21.0",
-				"@walletconnect/utils": "2.21.0",
-				"es-toolkit": "1.33.0",
+				"@walletconnect/logger": "3.0.2",
+				"@walletconnect/sign-client": "2.23.7",
+				"@walletconnect/types": "2.23.7",
+				"@walletconnect/utils": "2.23.7",
+				"es-toolkit": "1.44.0",
 				"events": "3.3.0"
 			}
 		},
 		"node_modules/@reown/appkit/node_modules/@walletconnect/utils": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
-			"integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
-			"license": "Apache-2.0",
+			"version": "2.23.7",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+			"integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@noble/ciphers": "1.2.1",
-				"@noble/curves": "1.8.1",
-				"@noble/hashes": "1.7.1",
+				"@msgpack/msgpack": "3.1.3",
+				"@noble/ciphers": "1.3.0",
+				"@noble/curves": "1.9.7",
+				"@noble/hashes": "1.8.0",
+				"@scure/base": "1.2.6",
 				"@walletconnect/jsonrpc-utils": "1.0.8",
 				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "3.0.2",
 				"@walletconnect/relay-api": "1.0.11",
 				"@walletconnect/relay-auth": "1.1.0",
 				"@walletconnect/safe-json": "1.0.2",
 				"@walletconnect/time": "1.0.2",
-				"@walletconnect/types": "2.21.0",
+				"@walletconnect/types": "2.23.7",
 				"@walletconnect/window-getters": "1.0.1",
 				"@walletconnect/window-metadata": "1.0.1",
-				"bs58": "6.0.0",
+				"blakejs": "1.2.1",
 				"detect-browser": "5.3.0",
-				"query-string": "7.1.3",
-				"uint8arrays": "3.1.0",
-				"viem": "2.23.2"
+				"ox": "0.9.3",
+				"uint8arrays": "3.1.1"
 			}
 		},
-		"node_modules/@reown/appkit/node_modules/@walletconnect/utils/node_modules/viem": {
-			"version": "2.23.2",
-			"resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
-			"integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
+		"node_modules/@reown/appkit/node_modules/es-toolkit": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+			"integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
 			"license": "MIT",
-			"dependencies": {
-				"@noble/curves": "1.8.1",
-				"@noble/hashes": "1.7.1",
-				"@scure/bip32": "1.6.2",
-				"@scure/bip39": "1.5.4",
-				"abitype": "1.0.8",
-				"isows": "1.0.6",
-				"ox": "0.6.7",
-				"ws": "8.18.0"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
 		},
-		"node_modules/@reown/appkit/node_modules/abitype": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-			"integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+		"node_modules/@reown/appkit/node_modules/on-exit-leak-free": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+			"integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
 			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/wevm"
-			},
-			"peerDependencies": {
-				"typescript": ">=5.0.4",
-				"zod": "^3 >=3.22.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				},
-				"zod": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@reown/appkit/node_modules/isows": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-			"integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"ws": "*"
+			"engines": {
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@reown/appkit/node_modules/ox": {
-			"version": "0.6.7",
-			"resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
-			"integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+			"integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
 			"funding": [
 				{
 					"type": "github",
@@ -4119,12 +4439,13 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@adraffy/ens-normalize": "^1.10.1",
-				"@noble/curves": "^1.6.0",
-				"@noble/hashes": "^1.5.0",
-				"@scure/bip32": "^1.5.0",
-				"@scure/bip39": "^1.4.0",
-				"abitype": "^1.0.6",
+				"@adraffy/ens-normalize": "^1.11.0",
+				"@noble/ciphers": "^1.3.0",
+				"@noble/curves": "1.9.1",
+				"@noble/hashes": "^1.8.0",
+				"@scure/bip32": "^1.7.0",
+				"@scure/bip39": "^1.6.0",
+				"abitype": "^1.0.9",
 				"eventemitter3": "5.0.1"
 			},
 			"peerDependencies": {
@@ -4134,6 +4455,122 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/ox/node_modules/@noble/curves": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+			"integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "1.8.0"
+			},
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/pino": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+			"integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^2.0.0",
+				"pino-std-serializers": "^7.0.0",
+				"process-warning": "^5.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"slow-redact": "^0.3.0",
+				"sonic-boom": "^4.0.1",
+				"thread-stream": "^3.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/pino-abstract-transport": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+			"integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+			"license": "MIT",
+			"dependencies": {
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/pino-std-serializers": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+			"integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit/node_modules/process-warning": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+			"integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@reown/appkit/node_modules/real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.13.0"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/sonic-boom": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+			"integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/thread-stream": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+			"integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+			"license": "MIT",
+			"dependencies": {
+				"real-require": "^0.2.0"
+			}
+		},
+		"node_modules/@reown/appkit/node_modules/uint8arrays": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+			"integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+			"license": "MIT",
+			"dependencies": {
+				"multiformats": "^9.4.2"
 			}
 		},
 		"node_modules/@rtsao/scc": {
@@ -4363,9 +4800,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4383,9 +4817,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4403,9 +4834,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4423,9 +4851,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5029,9 +5454,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5046,9 +5468,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5063,9 +5482,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5080,9 +5496,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5097,9 +5510,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5114,9 +5524,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5131,9 +5538,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5148,9 +5552,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5165,9 +5566,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5182,9 +5580,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5265,49 +5660,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/@vanilla-extract/css": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.20.1.tgz",
-			"integrity": "sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==",
-			"license": "MIT",
-			"dependencies": {
-				"@emotion/hash": "^0.9.0",
-				"@vanilla-extract/private": "^1.0.9",
-				"css-what": "^6.1.0",
-				"csstype": "^3.2.3",
-				"dedent": "^1.5.3",
-				"deep-object-diff": "^1.1.9",
-				"deepmerge": "^4.2.2",
-				"lru-cache": "^10.4.3",
-				"media-query-parser": "^2.0.2",
-				"modern-ahocorasick": "^1.0.0",
-				"picocolors": "^1.0.0"
-			}
-		},
-		"node_modules/@vanilla-extract/dynamic": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vanilla-extract/dynamic/-/dynamic-2.1.5.tgz",
-			"integrity": "sha512-QGIFGb1qyXQkbzx6X6i3+3LMc/iv/ZMBttMBL+Wm/DetQd36KsKsFg5CtH3qy+1hCA/5w93mEIIAiL4fkM8ycw==",
-			"license": "MIT",
-			"dependencies": {
-				"@vanilla-extract/private": "^1.0.9"
-			}
-		},
-		"node_modules/@vanilla-extract/private": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.9.tgz",
-			"integrity": "sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==",
-			"license": "MIT"
-		},
-		"node_modules/@vanilla-extract/sprinkles": {
-			"version": "1.6.5",
-			"resolved": "https://registry.npmjs.org/@vanilla-extract/sprinkles/-/sprinkles-1.6.5.tgz",
-			"integrity": "sha512-HOYidLONR/SeGk8NBAeI64I4gYdsMX9vJmniL13ZcLVwawyK0s2GUENEAcGA+GYLIoeyQB61UqmhqPodJry7zA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@vanilla-extract/css": "^1.0.0"
-			}
 		},
 		"node_modules/@wagmi/connectors": {
 			"version": "6.2.0",
@@ -5395,6 +5747,27 @@
 				}
 			}
 		},
+		"node_modules/@wallet-standard/base": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+			"integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/@wallet-standard/wallet": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+			"integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@wallet-standard/base": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/@walletconnect/core": {
 			"version": "2.21.1",
 			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.1.tgz",
@@ -5456,6 +5829,747 @@
 				"@walletconnect/universal-provider": "2.21.1",
 				"@walletconnect/utils": "2.21.1",
 				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@noble/ciphers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
+			"integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@noble/curves": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+			"integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "1.7.1"
+			},
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@noble/hashes": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+			"integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.7.8.tgz",
+			"integrity": "sha512-51kTleozhA618T1UvMghkhKfaPcc9JlKwLJ5uV+riHyvSoWPKPRIa5A6M1Wano5puNyW0s3fwywhyqTHSilkaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@reown/appkit-common": "1.7.8",
+				"@reown/appkit-controllers": "1.7.8",
+				"@reown/appkit-pay": "1.7.8",
+				"@reown/appkit-polyfills": "1.7.8",
+				"@reown/appkit-scaffold-ui": "1.7.8",
+				"@reown/appkit-ui": "1.7.8",
+				"@reown/appkit-utils": "1.7.8",
+				"@reown/appkit-wallet": "1.7.8",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/universal-provider": "2.21.0",
+				"bs58": "6.0.0",
+				"valtio": "1.13.2",
+				"viem": ">=2.29.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-common": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.7.8.tgz",
+			"integrity": "sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"big.js": "6.2.2",
+				"dayjs": "1.11.13",
+				"viem": ">=2.29.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-controllers": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.7.8.tgz",
+			"integrity": "sha512-IdXlJlivrlj6m63VsGLsjtPHHsTWvKGVzWIP1fXZHVqmK+rZCBDjCi9j267Rb9/nYRGHWBtlFQhO8dK35WfeDA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@reown/appkit-common": "1.7.8",
+				"@reown/appkit-wallet": "1.7.8",
+				"@walletconnect/universal-provider": "2.21.0",
+				"valtio": "1.13.2",
+				"viem": ">=2.29.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/sign-client": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
+			"integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
+			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/core": "2.21.0",
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/utils": "2.21.0",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/types": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
+			"integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/universal-provider": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
+			"integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
+			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/jsonrpc-http-connection": "1.0.8",
+				"@walletconnect/jsonrpc-provider": "1.0.14",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/sign-client": "2.21.0",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/utils": "2.21.0",
+				"es-toolkit": "1.33.0",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
+			"integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@noble/ciphers": "1.2.1",
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/relay-api": "1.0.11",
+				"@walletconnect/relay-auth": "1.1.0",
+				"@walletconnect/safe-json": "1.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/window-getters": "1.0.1",
+				"@walletconnect/window-metadata": "1.0.1",
+				"bs58": "6.0.0",
+				"detect-browser": "5.3.0",
+				"query-string": "7.1.3",
+				"uint8arrays": "3.1.0",
+				"viem": "2.23.2"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-controllers/node_modules/@walletconnect/utils/node_modules/viem": {
+			"version": "2.23.2",
+			"resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
+			"integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@scure/bip32": "1.6.2",
+				"@scure/bip39": "1.5.4",
+				"abitype": "1.0.8",
+				"isows": "1.0.6",
+				"ox": "0.6.7",
+				"ws": "8.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.0.4"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-pay": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
+			"integrity": "sha512-OSGQ+QJkXx0FEEjlpQqIhT8zGJKOoHzVnyy/0QFrl3WrQTjCzg0L6+i91Ad5Iy1zb6V5JjqtfIFpRVRWN4M3pw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@reown/appkit-common": "1.7.8",
+				"@reown/appkit-controllers": "1.7.8",
+				"@reown/appkit-ui": "1.7.8",
+				"@reown/appkit-utils": "1.7.8",
+				"lit": "3.3.0",
+				"valtio": "1.13.2"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-polyfills": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.7.8.tgz",
+			"integrity": "sha512-W/kq786dcHHAuJ3IV2prRLEgD/2iOey4ueMHf1sIFjhhCGMynMkhsOhQMUH0tzodPqUgAC494z4bpIDYjwWXaA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"buffer": "6.0.3"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-scaffold-ui": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.7.8.tgz",
+			"integrity": "sha512-RCeHhAwOrIgcvHwYlNWMcIDibdI91waaoEYBGw71inE0kDB8uZbE7tE6DAXJmDkvl0qPh+DqlC4QbJLF1FVYdQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@reown/appkit-common": "1.7.8",
+				"@reown/appkit-controllers": "1.7.8",
+				"@reown/appkit-ui": "1.7.8",
+				"@reown/appkit-utils": "1.7.8",
+				"@reown/appkit-wallet": "1.7.8",
+				"lit": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-ui": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.7.8.tgz",
+			"integrity": "sha512-1hjCKjf6FLMFzrulhl0Y9Vb9Fu4royE+SXCPSWh4VhZhWqlzUFc7kutnZKx8XZFVQH4pbBvY62SpRC93gqoHow==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@reown/appkit-common": "1.7.8",
+				"@reown/appkit-controllers": "1.7.8",
+				"@reown/appkit-wallet": "1.7.8",
+				"lit": "3.3.0",
+				"qrcode": "1.5.3"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-utils": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.7.8.tgz",
+			"integrity": "sha512-8X7UvmE8GiaoitCwNoB86pttHgQtzy4ryHZM9kQpvjQ0ULpiER44t1qpVLXNM4X35O0v18W0Dk60DnYRMH2WRw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@reown/appkit-common": "1.7.8",
+				"@reown/appkit-controllers": "1.7.8",
+				"@reown/appkit-polyfills": "1.7.8",
+				"@reown/appkit-wallet": "1.7.8",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/universal-provider": "2.21.0",
+				"valtio": "1.13.2",
+				"viem": ">=2.29.0"
+			},
+			"peerDependencies": {
+				"valtio": "1.13.2"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-utils/node_modules/@walletconnect/sign-client": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
+			"integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
+			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/core": "2.21.0",
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/utils": "2.21.0",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-utils/node_modules/@walletconnect/types": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
+			"integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-utils/node_modules/@walletconnect/universal-provider": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
+			"integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
+			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/jsonrpc-http-connection": "1.0.8",
+				"@walletconnect/jsonrpc-provider": "1.0.14",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/sign-client": "2.21.0",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/utils": "2.21.0",
+				"es-toolkit": "1.33.0",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
+			"integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@noble/ciphers": "1.2.1",
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/relay-api": "1.0.11",
+				"@walletconnect/relay-auth": "1.1.0",
+				"@walletconnect/safe-json": "1.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/window-getters": "1.0.1",
+				"@walletconnect/window-metadata": "1.0.1",
+				"bs58": "6.0.0",
+				"detect-browser": "5.3.0",
+				"query-string": "7.1.3",
+				"uint8arrays": "3.1.0",
+				"viem": "2.23.2"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils/node_modules/viem": {
+			"version": "2.23.2",
+			"resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
+			"integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@scure/bip32": "1.6.2",
+				"@scure/bip39": "1.5.4",
+				"abitype": "1.0.8",
+				"isows": "1.0.6",
+				"ox": "0.6.7",
+				"ws": "8.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.0.4"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit-wallet": {
+			"version": "1.7.8",
+			"resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
+			"integrity": "sha512-kspz32EwHIOT/eg/ZQbFPxgXq0B/olDOj3YMu7gvLEFz4xyOFd/wgzxxAXkp5LbG4Cp++s/elh79rVNmVFdB9A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@reown/appkit-common": "1.7.8",
+				"@reown/appkit-polyfills": "1.7.8",
+				"@walletconnect/logger": "2.1.2",
+				"zod": "3.22.4"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit/node_modules/@walletconnect/sign-client": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.21.0.tgz",
+			"integrity": "sha512-z7h+PeLa5Au2R591d/8ZlziE0stJvdzP9jNFzFolf2RG/OiXulgFKum8PrIyXy+Rg2q95U9nRVUF9fWcn78yBA==",
+			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/core": "2.21.0",
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/utils": "2.21.0",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit/node_modules/@walletconnect/types": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
+			"integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit/node_modules/@walletconnect/universal-provider": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.21.0.tgz",
+			"integrity": "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==",
+			"deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/jsonrpc-http-connection": "1.0.8",
+				"@walletconnect/jsonrpc-provider": "1.0.14",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/sign-client": "2.21.0",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/utils": "2.21.0",
+				"es-toolkit": "1.33.0",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit/node_modules/@walletconnect/utils": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
+			"integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@noble/ciphers": "1.2.1",
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/relay-api": "1.0.11",
+				"@walletconnect/relay-auth": "1.1.0",
+				"@walletconnect/safe-json": "1.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/window-getters": "1.0.1",
+				"@walletconnect/window-metadata": "1.0.1",
+				"bs58": "6.0.0",
+				"detect-browser": "5.3.0",
+				"query-string": "7.1.3",
+				"uint8arrays": "3.1.0",
+				"viem": "2.23.2"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@reown/appkit/node_modules/@walletconnect/utils/node_modules/viem": {
+			"version": "2.23.2",
+			"resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
+			"integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@scure/bip32": "1.6.2",
+				"@scure/bip39": "1.5.4",
+				"abitype": "1.0.8",
+				"isows": "1.0.6",
+				"ox": "0.6.7",
+				"ws": "8.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.0.4"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@scure/bip32": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+			"integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/curves": "~1.8.1",
+				"@noble/hashes": "~1.7.1",
+				"@scure/base": "~1.2.2"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@scure/bip39": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+			"integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "~1.7.1",
+				"@scure/base": "~1.2.4"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/core": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.21.0.tgz",
+			"integrity": "sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-provider": "1.0.14",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/jsonrpc-ws-connection": "1.0.16",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"@walletconnect/relay-api": "1.0.11",
+				"@walletconnect/relay-auth": "1.1.0",
+				"@walletconnect/safe-json": "1.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/utils": "2.21.0",
+				"@walletconnect/window-getters": "1.0.1",
+				"es-toolkit": "1.33.0",
+				"events": "3.3.0",
+				"uint8arrays": "3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/core/node_modules/@walletconnect/types": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.21.0.tgz",
+			"integrity": "sha512-ll+9upzqt95ZBWcfkOszXZkfnpbJJ2CmxMfGgE5GmhdxxxCcO5bGhXkI+x8OpiS555RJ/v/sXJYMSOLkmu4fFw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@walletconnect/events": "1.0.1",
+				"@walletconnect/heartbeat": "1.2.2",
+				"@walletconnect/jsonrpc-types": "1.0.4",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/logger": "2.1.2",
+				"events": "3.3.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/core/node_modules/@walletconnect/utils": {
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.21.0.tgz",
+			"integrity": "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@noble/ciphers": "1.2.1",
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@walletconnect/jsonrpc-utils": "1.0.8",
+				"@walletconnect/keyvaluestorage": "1.1.1",
+				"@walletconnect/relay-api": "1.0.11",
+				"@walletconnect/relay-auth": "1.1.0",
+				"@walletconnect/safe-json": "1.0.2",
+				"@walletconnect/time": "1.0.2",
+				"@walletconnect/types": "2.21.0",
+				"@walletconnect/window-getters": "1.0.1",
+				"@walletconnect/window-metadata": "1.0.1",
+				"bs58": "6.0.0",
+				"detect-browser": "5.3.0",
+				"query-string": "7.1.3",
+				"uint8arrays": "3.1.0",
+				"viem": "2.23.2"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/core/node_modules/viem": {
+			"version": "2.23.2",
+			"resolved": "https://registry.npmjs.org/viem/-/viem-2.23.2.tgz",
+			"integrity": "sha512-NVmW/E0c5crMOtbEAqMF0e3NmvQykFXhLOc/CkLIXOlzHSA6KXVz3CYVmaKqBF8/xtjsjHAGjdJN3Ru1kFJLaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@noble/curves": "1.8.1",
+				"@noble/hashes": "1.7.1",
+				"@scure/bip32": "1.6.2",
+				"@scure/bip39": "1.5.4",
+				"abitype": "1.0.8",
+				"isows": "1.0.6",
+				"ox": "0.6.7",
+				"ws": "8.18.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.0.4"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/abitype": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+			"integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/wevm"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.0.4",
+				"zod": "^3 >=3.22.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/isows": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+			"integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"ws": "*"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/ox": {
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
+			"integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/wevm"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@adraffy/ens-normalize": "^1.10.1",
+				"@noble/curves": "^1.6.0",
+				"@noble/hashes": "^1.5.0",
+				"@scure/bip32": "^1.5.0",
+				"@scure/bip39": "^1.4.0",
+				"abitype": "^1.0.6",
+				"eventemitter3": "5.0.1"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.4.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/proxy-compare": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.6.0.tgz",
+			"integrity": "sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw==",
+			"license": "MIT"
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/react": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/use-sync-external-store": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/valtio": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
+			"integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
+			"license": "MIT",
+			"dependencies": {
+				"derive-valtio": "0.1.0",
+				"proxy-compare": "2.6.0",
+				"use-sync-external-store": "1.2.0"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8",
+				"react": ">=16.8"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@walletconnect/ethereum-provider/node_modules/zod": {
+			"version": "3.22.4",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+			"integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@walletconnect/events": {
@@ -5901,6 +7015,17 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@walletconnect/utils/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@walletconnect/window-getters": {
@@ -6411,6 +7536,12 @@
 				"node": "*"
 			}
 		},
+		"node_modules/blakejs": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+			"integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+			"license": "MIT"
+		},
 		"node_modules/bn.js": {
 			"version": "4.12.3",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
@@ -6704,15 +7835,6 @@
 				"wrap-ansi": "^6.2.0"
 			}
 		},
-		"node_modules/clsx": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6832,48 +7954,12 @@
 				"node": "*"
 			}
 		},
-		"node_modules/css-what": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"devOptional": true,
 			"license": "MIT"
-		},
-		"node_modules/cuer": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/cuer/-/cuer-0.0.3.tgz",
-			"integrity": "sha512-f/UNxRMRCYtfLEGECAViByA3JNflZImOk11G9hwSd+44jvzrc99J35u5l+fbdQ2+ZG441GvOpaeGYBmWquZsbQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/wevm"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"qr": "~0"
-			},
-			"peerDependencies": {
-				"react": ">=18",
-				"react-dom": ">=18",
-				"typescript": ">=5.4.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
@@ -6993,41 +8079,12 @@
 				"node": ">=0.10"
 			}
 		},
-		"node_modules/dedent": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"babel-plugin-macros": "^3.1.0"
-			},
-			"peerDependenciesMeta": {
-				"babel-plugin-macros": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/deep-object-diff": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
-			"integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==",
-			"license": "MIT"
-		},
-		"node_modules/deepmerge": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
@@ -7100,26 +8157,6 @@
 			"integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
 			"license": "MIT"
 		},
-		"node_modules/detect-europe-js": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-			"integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7129,12 +8166,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/detect-node-es": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-			"license": "MIT"
 		},
 		"node_modules/dijkstrajs": {
 			"version": "1.0.3",
@@ -8400,15 +9431,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-nonce": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/get-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -9099,26 +10121,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-standalone-pwa": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-			"integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -9296,7 +10298,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -9608,9 +10609,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9632,9 +10630,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9656,9 +10651,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9680,9 +10672,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9802,7 +10791,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
@@ -9810,12 +10798,6 @@
 			"bin": {
 				"loose-envify": "cli.js"
 			}
-		},
-		"node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"license": "ISC"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -9845,15 +10827,6 @@
 				"charenc": "0.0.2",
 				"crypt": "0.0.2",
 				"is-buffer": "~1.1.6"
-			}
-		},
-		"node_modules/media-query-parser": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/media-query-parser/-/media-query-parser-2.0.2.tgz",
-			"integrity": "sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.12.5"
 			}
 		},
 		"node_modules/merge2": {
@@ -9955,12 +10928,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/modern-ahocorasick": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/modern-ahocorasick/-/modern-ahocorasick-1.1.0.tgz",
-			"integrity": "sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==",
-			"license": "MIT"
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
@@ -10791,9 +11758,9 @@
 			}
 		},
 		"node_modules/proxy-compare": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.6.0.tgz",
-			"integrity": "sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+			"integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
 			"license": "MIT"
 		},
 		"node_modules/proxy-from-env": {
@@ -10823,15 +11790,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/qr": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/qr/-/qr-0.6.0.tgz",
-			"integrity": "sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA==",
-			"license": "(MIT OR Apache-2.0)",
-			"engines": {
-				"node": ">= 20.19.0"
 			}
 		},
 		"node_modules/qrcode": {
@@ -10930,75 +11888,6 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/react-remove-scroll": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-			"integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-			"license": "MIT",
-			"dependencies": {
-				"react-remove-scroll-bar": "^2.3.7",
-				"react-style-singleton": "^2.2.3",
-				"tslib": "^2.1.0",
-				"use-callback-ref": "^1.3.3",
-				"use-sidecar": "^1.1.3"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/react-remove-scroll-bar": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-			"license": "MIT",
-			"dependencies": {
-				"react-style-singleton": "^2.2.2",
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/react-style-singleton": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-			"license": "MIT",
-			"dependencies": {
-				"get-nonce": "^1.0.0",
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
@@ -11530,6 +12419,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/slow-redact": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+			"integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+			"license": "MIT"
 		},
 		"node_modules/socket.io-client": {
 			"version": "4.8.3",
@@ -12169,57 +13064,6 @@
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
-		"node_modules/ua-is-frozen": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-			"integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/ua-parser-js": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
-			"integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				}
-			],
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"detect-europe-js": "^0.1.2",
-				"is-standalone-pwa": "^0.1.1",
-				"ua-is-frozen": "^0.1.2"
-			},
-			"bin": {
-				"ua-parser-js": "script/cli.js"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/ufo": {
 			"version": "1.6.4",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
@@ -12450,49 +13294,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/use-callback-ref": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/use-sidecar": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-			"license": "MIT",
-			"dependencies": {
-				"detect-node-es": "^1.1.0",
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/use-sync-external-store": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
@@ -12548,21 +13349,19 @@
 			}
 		},
 		"node_modules/valtio": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
-			"integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
+			"integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
 			"license": "MIT",
 			"dependencies": {
-				"derive-valtio": "0.1.0",
-				"proxy-compare": "2.6.0",
-				"use-sync-external-store": "1.2.0"
+				"proxy-compare": "^3.0.1"
 			},
 			"engines": {
 				"node": ">=12.20.0"
 			},
 			"peerDependencies": {
-				"@types/react": ">=16.8",
-				"react": ">=16.8"
+				"@types/react": ">=18.0.0",
+				"react": ">=18.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -12571,15 +13370,6 @@
 				"react": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/valtio/node_modules/use-sync-external-store": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/viem": {

--- a/src/package.json
+++ b/src/package.json
@@ -43,7 +43,8 @@
 		"cache:clear:next": "rm -rf .next"
 	},
 	"dependencies": {
-		"@rainbow-me/rainbowkit": "^2.2.11",
+		"@reown/appkit": "^1.8.20",
+		"@reown/appkit-adapter-wagmi": "^1.8.20",
 		"@tanstack/react-query": "^5.100.10",
 		"arweave": "^1.15.7",
 		"next": "16.2.6",


### PR DESCRIPTION
## Summary

Completes **Phase 3, item 1** (Safari wallet compatibility) and adds the requested wallets. Replaces RainbowKit with **Reown AppKit** (`@reown/appkit` + `@reown/appkit-adapter-wagmi`), the only mainstream library that supports all the requested wallets without a deprecated connector.

### Why a library swap
- RainbowKit **deprecated its Coinbase Wallet connector** (pushes to Base Account); AppKit keeps Coinbase first-class.
- RainbowKit ships **no Tangem** wallet; AppKit pulls the full WalletConnect registry, so Tangem and Phantom are available and can be featured.

### Changes
- `src/lib/wagmi.ts`: build the wagmi config via the AppKit wagmi adapter and create the AppKit modal. Features **Coinbase, MetaMask, Phantom, Tangem, and Base** by verified WalletConnect-registry IDs. Preserves all contract-address exports and `getExplorerTxUrl`.
- New `src/components/ConnectButton.tsx` (AppKit `useAppKit`/`useAppKitAccount` hooks) replaces RainbowKit's `<ConnectButton>` across the navbar and all six pages.
- `Providers.tsx`: drop `RainbowKitProvider`; sync AppKit light/dark theme with `next-themes`.

### Safari fixes
- No more broken `metamask://` deep link when the extension is absent.
- Relay-dependent wallets (MetaMask QR, Phantom, Tangem, WalletConnect) require `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` (documented in `.env.example`); injected and Coinbase work without it.

### Docs
- Synced `README.md`, `src/README.md`, `docs/PRESENTATION.md`, `docs/MISCELLANEOUS.md`, and checked off the item in `TODO.md`.

## Verification
- `tsc`, ESLint, Prettier, and `next build` all pass locally.
- ⚠️ Real-device QA on iOS Safari is still recommended before mainnet — the wallet flows can't be exercised headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)