### PR TITLE
refactor(wallet): WALLET_IDS constants module + more featured wallets

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -487,6 +487,41 @@ time.
 
 ---
 
+## Wallet Connection (Reown AppKit)
+
+The frontend connects wallets through [Reown AppKit](https://reown.com/appkit)
+(`@reown/appkit` + `@reown/appkit-adapter-wagmi`) rather than RainbowKit. AppKit
+pulls the full WalletConnect wallet registry, which keeps Coinbase Wallet
+first-class (RainbowKit deprecated its connector) and adds wallets RainbowKit
+does not ship (for example Tangem). Two `src/lib` modules drive it:
+
+| File               | Responsibility                                                                                                         |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `lib/wagmi.ts`     | Builds the wagmi `config` via the AppKit adapter and calls `createAppKit({ … })`, passing `featuredWalletIds`.         |
+| `lib/walletIds.ts` | `WALLET_IDS` — a named map of WalletConnect registry IDs — and the ordered `FEATURED_WALLET_IDS` array consumed above. |
+
+`featuredWalletIds` only controls which wallets are **pinned** to the top of the
+modal and in what order; every other registry wallet still appears under "All
+Wallets". The featured order is:
+
+1. **Primary (shown first):** Base, MetaMask, Phantom, Tangem.
+2. **Additional popular wallets:** Coinbase, Solflare, Robinhood, Cold Wallet,
+   Brave, SoulSwap, Trust, OKX, Rainbow, Zerion.
+
+Each ID is the wallet's WalletConnect/Reown registry ID, looked up via the
+explorer API (`https://explorer-api.walletconnect.com/v3/wallets`) and browsable
+at
+[walletguide.walletconnect.network](https://walletguide.walletconnect.network).
+To add or reorder a wallet, edit `WALLET_IDS` and `FEATURED_WALLET_IDS` in
+`lib/walletIds.ts` — no change to `lib/wagmi.ts` is required.
+
+Wallets that pair over the WalletConnect relay (MetaMask QR, Phantom, Tangem,
+WalletConnect itself) need a real `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID`;
+injected and Coinbase work without it, which keeps desktop and iOS Safari
+connections reliable.
+
+---
+
 ## Threat Mitigations
 
 The following mechanisms address the protocol's stated threat model directly.

--- a/src/README.md
+++ b/src/README.md
@@ -298,7 +298,8 @@ src/
 │   ├── ipfs.ts                       # IPFS upload via Pinata's pinning API; returns CID for on-chain storage
 │   ├── magicLink.ts                  # JWT sign/verify helpers for freelancer magic-link onboarding
 │   ├── utils.ts                      # Address shortener, ETH formatter, status color map
-│   └── wagmi.ts                      # wagmi config (chains, transports) + contract address resolver
+│   ├── wagmi.ts                      # wagmi config + AppKit modal (chains, address resolver, featured wallets)
+│   └── walletIds.ts                  # WalletConnect registry IDs for the AppKit featured-wallet list
 │
 ├── public/                           # Static assets served at the root URL
 │   ├── logo.png                      # TrustLedger project logo
@@ -338,15 +339,16 @@ src/
 
 ### Library - `lib/`
 
-| File            | Description                                                                                                                                |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `abi.ts`        | Contract ABIs including `REPUTATION_REGISTRY_ABI`; `STATUS_LABELS` for human-readable contract status strings                              |
-| `arweave.ts`    | Uploads files to Arweave for permanent, immutable storage; returns the transaction ID as a URI                                             |
-| `encryption.ts` | AES-GCM helpers: `encrypt(data, key)` → ciphertext, `decrypt(ciphertext, key)` → plaintext                                                 |
-| `ipfs.ts`       | Uploads a `File` or `Blob` to IPFS via Pinata (`uploadToPinata`); returns the IPFS CID used as `contractURI` or `proofOfWorkURI`           |
-| `magicLink.ts`  | `signMagicLink(contractId, freelancerAddress)` / `verifyMagicLink(token)` - JWT helpers for the accept flow                                |
-| `utils.ts`      | `shortenAddress`, `formatEth`, `statusColor` - formatting helpers used across pages                                                        |
-| `wagmi.ts`      | Exports `config` and contract addresses (`TRUSTLEDGER_ADDRESS`, `REPUTATION_REGISTRY_ADDRESS`, etc.) from env or `deployed-addresses.json` |
+| File            | Description                                                                                                                                                                                                              |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `abi.ts`        | Contract ABIs including `REPUTATION_REGISTRY_ABI`; `STATUS_LABELS` for human-readable contract status strings                                                                                                            |
+| `arweave.ts`    | Uploads files to Arweave for permanent, immutable storage; returns the transaction ID as a URI                                                                                                                           |
+| `encryption.ts` | AES-GCM helpers: `encrypt(data, key)` → ciphertext, `decrypt(ciphertext, key)` → plaintext                                                                                                                               |
+| `ipfs.ts`       | Uploads a `File` or `Blob` to IPFS via Pinata (`uploadToPinata`); returns the IPFS CID used as `contractURI` or `proofOfWorkURI`                                                                                         |
+| `magicLink.ts`  | `signMagicLink(contractId, freelancerAddress)` / `verifyMagicLink(token)` - JWT helpers for the accept flow                                                                                                              |
+| `utils.ts`      | `shortenAddress`, `formatEth`, `statusColor` - formatting helpers used across pages                                                                                                                                      |
+| `wagmi.ts`      | Exports `config` (built by the Reown AppKit wagmi adapter), creates the AppKit modal, and resolves contract addresses (`TRUSTLEDGER_ADDRESS`, `REPUTATION_REGISTRY_ADDRESS`, etc.) from env or `deployed-addresses.json` |
+| `walletIds.ts`  | `WALLET_IDS` map of WalletConnect registry IDs and the ordered `FEATURED_WALLET_IDS` list for the AppKit modal (Base, MetaMask, Phantom, Tangem first, then Coinbase, Solflare, Robinhood, Cold, Brave, SoulSwap, …)     |
 
 [↑ Back to top](#table-of-contents)
 

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -1,6 +1,7 @@
 import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 import { arbitrum, type AppKitNetwork, base, optimism, sepolia } from "@reown/appkit/networks";
 import { createAppKit, type CreateAppKit } from "@reown/appkit/react";
+import { FEATURED_WALLET_IDS } from "./walletIds";
 
 export const TRUSTLEDGER_ADDRESS: `0x${string}` =
 	(process.env["NEXT_PUBLIC_TRUSTLEDGER_ADDRESS"] as `0x${string}` | undefined) ??
@@ -39,17 +40,6 @@ const ACCENT_COLOR = "#6366f1";
 const appUrl =
 	process.env["NEXT_PUBLIC_SITE_URL"] ??
 	(typeof window !== "undefined" ? window.location.origin : "https://trustledger.vercel.app");
-
-// Verified WalletConnect Explorer IDs, surfaced first in the connect modal.
-// These are the wallets we explicitly support; AppKit still lists every other
-// registry wallet under "All Wallets".
-const FEATURED_WALLET_IDS = [
-	"d0ca99ff52b99abc48743dad0f7fc891e041be73574f7fac4afe5d4bb83845c8", // Coinbase Wallet
-	"c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96", // MetaMask
-	"a797aa35c0fadbfc1a53e7f675162ed5226968b44a19ee3d24385c64d1d3c393", // Phantom
-	"21030f20fba1a77115858ee3a8bc5841c739ab4537441316e2f4b1d0a8d218af", // Tangem
-	"fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa", // Base Account
-];
 
 // The wagmi adapter builds the wagmi config AppKit drives. `ssr: true` mirrors
 // the previous getDefaultConfig setup so Next.js server rendering stays correct.

--- a/src/lib/walletIds.ts
+++ b/src/lib/walletIds.ts
@@ -1,0 +1,50 @@
+/**
+ * WalletConnect Explorer wallet IDs used to feature specific wallets in the
+ * Reown AppKit connect modal (consumed by `featuredWalletIds` in `lib/wagmi.ts`).
+ *
+ * Each value is the wallet's WalletConnect/Reown registry ID, looked up via the
+ * explorer API (https://explorer-api.walletconnect.com/v3/wallets) and browsable
+ * at https://walletguide.walletconnect.network. AppKit still lists every other
+ * registry wallet under "All Wallets" — featuring only controls what is pinned,
+ * and in what order, at the top of the modal.
+ */
+export const WALLET_IDS = {
+	// ─── Primary wallets (surfaced first, in this order) ───────────────────────
+	base: "fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa",
+	metaMask: "c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96",
+	phantom: "a797aa35c0fadbfc1a53e7f675162ed5226968b44a19ee3d24385c64d1d3c393",
+	tangem: "21030f20fba1a77115858ee3a8bc5841c739ab4537441316e2f4b1d0a8d218af",
+	// ─── Additional popular wallets ────────────────────────────────────────────
+	coinbase: "d0ca99ff52b99abc48743dad0f7fc891e041be73574f7fac4afe5d4bb83845c8",
+	solflare: "1ca0bdd4747578705b1939af023d120677c64fe6ca76add81fda36e350605e79",
+	robinhood: "8837dd9413b1d9b585ee937d27a816590248386d9dbf59f5cd3422dbbb65683e",
+	coldWallet: "dd15a3530dc4de4c50ebb22010824c41337403efec713f1187695c72934fb94c",
+	brave: "163d2cf19babf05eb8962e9748f9ebe613ed52ebf9c8107c9a0f104bfcf161b3",
+	soulSwap: "6d47c10f046c322b4882dbb6a4d8c8e5e439019402ff872412d3b79bd3a859f4",
+	trust: "4622a2b2d6af1c9844944291e5e7351a6aa24cd7b23099efac1b2fd875da31a0",
+	okx: "971e689d0a5be527bac79629b4ee9b925e82208e5168b733496a09c0faed0709",
+	rainbow: "1ae92b26df02f0abca6304df07debccd18262fdf5fe82daa81593582dac9a369",
+	zerion: "ecc4036f814562b41a5268adc86270fba1365471402006302e70169465b7ac18",
+} as const;
+
+/**
+ * Ordered list passed to AppKit's `featuredWalletIds`. The first four — Base,
+ * MetaMask, Phantom, and Tangem — are the primary wallets shown to users; the
+ * rest follow as additional popular options.
+ */
+export const FEATURED_WALLET_IDS: string[] = [
+	WALLET_IDS.base,
+	WALLET_IDS.metaMask,
+	WALLET_IDS.phantom,
+	WALLET_IDS.tangem,
+	WALLET_IDS.coinbase,
+	WALLET_IDS.solflare,
+	WALLET_IDS.robinhood,
+	WALLET_IDS.coldWallet,
+	WALLET_IDS.brave,
+	WALLET_IDS.soulSwap,
+	WALLET_IDS.trust,
+	WALLET_IDS.okx,
+	WALLET_IDS.rainbow,
+	WALLET_IDS.zerion,
+];


### PR DESCRIPTION
## Summary

- Extract the AppKit featured-wallet IDs into a dedicated **`src/lib/walletIds.ts`** module: a named `WALLET_IDS` map of WalletConnect registry IDs plus the ordered `FEATURED_WALLET_IDS` list. `lib/wagmi.ts` now imports `FEATURED_WALLET_IDS` instead of inlining it.
- **Expand the featured wallets.** Order shown in the connect modal:
  1. Primary (top): **Base, MetaMask, Phantom, Tangem**
  2. Additional popular: Coinbase, Solflare, Robinhood, Cold Wallet, Brave, SoulSwap, Trust, OKX, Rainbow, Zerion
  - All other registry wallets still appear under "All Wallets".
- **Docs:** document the module in `docs/ARCHITECTURE.md` (new *Wallet Connection (Reown AppKit)* section) and `src/README.md` (lib/ tree + table).

## Verification

- `tsc`, ESLint, Prettier, markdownlint, and `next build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)