### PR TITLE
feat: wallet UX, app-wide input validation, ReputationRegistry deploy automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,6 +166,12 @@ RESEND_FROM=TrustLedger <noreply@yourdomain.com>
 #   Production    : https://yourdomain.com
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# NEXT_PUBLIC_SITE_URL - origin advertised to wallets during WalletConnect/AppKit
+#   pairing (must match the real page origin or mobile wallets like Tangem reject
+#   the session). On the client the live origin is always used; this only sets the
+#   SSR/build fallback. Optional - NEXT_PUBLIC_APP_URL is used as an alias when unset.
+NEXT_PUBLIC_SITE_URL=
+
 # ─── Contract notifications & deadline reminders [OPTIONAL for email feature] ──
 # Reuse the same Resend setup above (RESEND_API_KEY / RESEND_FROM). These vars
 # gate the lifecycle-notification API and the deadline-reminder cron.

--- a/.env.local.example
+++ b/.env.local.example
@@ -50,6 +50,9 @@ NEXT_PUBLIC_PINATA_JWT=
 #   On Vercel this is derived automatically; set it only for local dev.
 #   Local dev: http://localhost:3000
 NEXT_PUBLIC_APP_URL=
+# NEXT_PUBLIC_SITE_URL — origin advertised to wallets during WalletConnect/AppKit
+#   pairing. Optional; falls back to NEXT_PUBLIC_APP_URL, then the live origin.
+NEXT_PUBLIC_SITE_URL=
 #
 # NEXT_PUBLIC_GITHUB_URL — source repo link shown in the navbar.
 #   On Vercel this is built from VERCEL_GIT_REPO_OWNER / VERCEL_GIT_REPO_SLUG.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,12 +104,15 @@ jobs:
                   TL=$(jq -r '.transactions[] | select(.contractName == "TrustLedger") | .contractAddress' "$BROADCAST")
                   ARB=$(jq -r '.transactions[] | select(.contractName == "Arbitration") | .contractAddress' "$BROADCAST")
                   JR=$(jq -r '.transactions[] | select(.contractName == "JurorRegistry") | .contractAddress' "$BROADCAST")
+                  REP=$(jq -r '.transactions[] | select(.contractName == "ReputationRegistry") | .contractAddress' "$BROADCAST")
                   echo "trustledger=$TL" >> "$GITHUB_OUTPUT"
                   echo "arbitration=$ARB" >> "$GITHUB_OUTPUT"
                   echo "juror_registry=$JR" >> "$GITHUB_OUTPUT"
+                  echo "reputation_registry=$REP" >> "$GITHUB_OUTPUT"
                   echo "Deployed TrustLedger: $TL"
                   echo "Deployed Arbitration: $ARB"
                   echo "Deployed JurorRegistry: $JR"
+                  echo "Deployed ReputationRegistry: $REP"
 
             # Upsert all three contract addresses in Vercel so the next frontend
             # build picks up the new addresses without any manual env var editing.
@@ -148,6 +151,7 @@ jobs:
                   upsert_env "NEXT_PUBLIC_TRUSTLEDGER_ADDRESS" "${{ steps.addresses.outputs.trustledger }}"
                   upsert_env "NEXT_PUBLIC_ARBITRATION_ADDRESS" "${{ steps.addresses.outputs.arbitration }}"
                   upsert_env "NEXT_PUBLIC_JUROR_REGISTRY_ADDRESS" "${{ steps.addresses.outputs.juror_registry }}"
+                  upsert_env "NEXT_PUBLIC_REPUTATION_REGISTRY_ADDRESS" "${{ steps.addresses.outputs.reputation_registry }}"
               env:
                   VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
                   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ Thumbs.db
 *.pem
 
 # ─── Next.js (src/) ───────────────────────────────────────────────────────────
+# /.next is the repo-root symlink `vercel-build` points at src/.next so Vercel
+# finds the output; src/.next/ is the actual Next.js build directory.
+/.next
 src/.next/
 src/out/
 src/build/

--- a/README.md
+++ b/README.md
@@ -711,8 +711,14 @@ You should see output like:
 JurorRegistry deployed to: 0x...
 TrustLedger   deployed to: 0x...
 Arbitration   deployed to: 0x...
+ReputationRegistry: 0x...
 Deployed addresses written to artifacts/deployed-addresses.json
 ```
+
+On the local node, the deploy also mirrors the four contract addresses into
+`src/.env.local` (via `scripts/sync-frontend-env.ts`) so the Next.js dev server
+resolves them - including `ReputationRegistry`, which powers the Reputation
+page. Re-run the sync standalone any time with `npm run sync:frontend:env`.
 
 **Run the demo scripts (optional):**
 
@@ -742,9 +748,11 @@ Make sure your `.env` has `SEPOLIA_RPC_URL`, `DEPLOYER_PUBLIC_ADDRESS`,
 npm run hardhat:deploy:sepolia
 ```
 
-The console prints all three contract addresses and writes them to
-`artifacts/deployed-addresses.json`. The frontend reads this file
-automatically - no manual copy step needed.
+The console prints all contract addresses and writes them to
+`artifacts/deployed-addresses.json`. For production, the GitHub Actions deploy
+workflow (`.github/workflows/deploy.yml`) upserts the `NEXT_PUBLIC_*_ADDRESS`
+vars - including `NEXT_PUBLIC_REPUTATION_REGISTRY_ADDRESS` - into Vercel, so the
+frontend picks them up on the next build with no manual copy step.
 
 To also verify the source code on Etherscan (requires `ETHERSCAN_API_KEY` in
 `.env`):
@@ -814,6 +822,7 @@ MetaMask connection and troubleshooting.
 | `npm run hardhat:gas`            | Run tests with per-function gas usage table                     |
 | `npm run node`                   | Local chain on `localhost:8545` with 20 pre-funded accounts     |
 | `npm run hardhat:deploy:local`   | Deploy to local node, write `artifacts/deployed-addresses.json` |
+| `npm run sync:frontend:env`      | Sync deployed addresses into `src/.env.local`                   |
 | `npm run hardhat:deploy:sepolia` | Deploy to Ethereum Sepolia                                      |
 | `npm run hardhat:check-balance`  | Print deployer ETH balance on Ethereum Sepolia                  |
 | `npm run demo:good`              | Happy-path demo against a running local node                    |
@@ -1259,17 +1268,21 @@ TrustLedger/
 │   │   ├── globals.css                           # Tailwind v4 base styles + font vars
 │   │   └── favicon.ico
 │   ├── components/
-│   │   ├── ConnectButton.tsx                     # Wallet connect button (opens the Reown AppKit modal)
+│   │   ├── ConnectButton.tsx                     # Wallet control: connect, copy address, reconnect hint
+│   │   ├── Field.tsx                             # Shared form primitives with inline validation errors
 │   │   ├── Navbar.tsx                            # Sticky nav with the wallet connect button
-│   │   ├── Providers.tsx                         # WagmiProvider + QueryClientProvider + AppKit theme sync
+│   │   ├── Providers.tsx                         # WagmiProvider + QueryClientProvider + AppKit theme sync + inactivity logout
 │   │   └── ThemeToggle.tsx                       # Light/dark mode toggle button
 │   ├── lib/
 │   │   ├── abi.ts                                # TrustLedger / Arbitration / JurorRegistry / ReputationRegistry ABIs
 │   │   ├── arweave.ts                            # Arweave permanent storage helper
 │   │   ├── encryption.ts                         # AES-GCM encrypt/decrypt for off-chain docs
 │   │   ├── ipfs.ts                               # IPFS upload via Pinata's pinning API
+│   │   ├── lastWallet.ts                         # Remembers the last-used connector label (localStorage)
 │   │   ├── magicLink.ts                          # JWT sign/verify for freelancer onboarding
+│   │   ├── useInactivityLogout.ts               # 10-min inactivity auto-disconnect hook
 │   │   ├── utils.ts                              # Address/ETH formatters, status colors
+│   │   ├── validation.ts                         # Reusable form-field validators
 │   │   └── wagmi.ts                              # wagmi config + contract address resolver
 │   ├── services/                                 # External-service integrations (server-only)
 │   │   ├── email.ts                             # Resend wrapper + shared HTML email shell
@@ -1299,6 +1312,7 @@ TrustLedger/
 │
 ├── scripts/
 │   ├── deploy.ts                         # Hardhat deploy (writes artifacts/deployed-addresses.json)
+│   ├── sync-frontend-env.ts             # Mirrors deployed addresses into src/.env.local
 │   ├── check-balance.ts                  # Deployer wallet balance checker
 │   ├── docker-demo.sh                    # Docker demo launcher
 │   ├── run-demo.sh                       # Interactive scenario runner (auto-starts node + deploy)

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -10,6 +10,7 @@ pragma solidity ^0.8.24;
 import {Script, console} from "forge-std/Script.sol";
 import {Arbitration} from "./../src/Arbitration.sol";
 import {JurorRegistry} from "./../src/JurorRegistry.sol";
+import {ReputationRegistry} from "./../src/ReputationRegistry.sol";
 import {TrustLedger} from "./../src/TrustLedger.sol";
 
 // Any Foundry script is a contract that extends Script.
@@ -18,7 +19,8 @@ import {TrustLedger} from "./../src/TrustLedger.sol";
 
 /// @title Deploy
 /// @author Kevin Le, Kellen Snider
-/// @notice Foundry deployment script for JurorRegistry, TrustLedger, and Arbitration.
+/// @notice Foundry deployment script for JurorRegistry, TrustLedger, Arbitration,
+///         and ReputationRegistry.
 contract Deploy is Script {
     /// @notice Reverts when a deployed contract lands at an unexpected address.
     error AddressMismatch();
@@ -92,6 +94,16 @@ contract Deploy is Script {
         console.log("JurorRegistry:", address(jurorRegistry));
         console.log("TrustLedger:  ", address(trustLedger));
         console.log("Arbitration:  ", address(arbitration));
+
+        // ── Deploy ReputationRegistry and wire it into TrustLedger ──────────────
+        // Deployed last (nonce N+3) so the nonce+1/nonce+2 predictions above are
+        // unaffected. ReputationRegistry stores TrustLedger as an immutable; in
+        // turn TrustLedger.initReputationRegistry() makes submitRating() live.
+        // initReputationRegistry is permissionless set-once (no owner role), so
+        // the deployer can call it here during the broadcast.
+        ReputationRegistry reputationRegistry = new ReputationRegistry(address(trustLedger));
+        trustLedger.initReputationRegistry(address(reputationRegistry));
+        console.log("ReputationRegistry:", address(reputationRegistry));
 
         // Stop signing/broadcasting transactions.
         vm.stopBroadcast();

--- a/docs/WALLETS.md
+++ b/docs/WALLETS.md
@@ -1,0 +1,81 @@
+# Wallets
+
+How TrustLedger connects wallets, what the connect button does, how sessions
+expire, and how to verify mobile wallets (including Tangem).
+
+## Connect button
+
+The connect control lives in `src/components/ConnectButton.tsx` and is backed by
+[Reown AppKit](https://reown.com) plus [wagmi](https://wagmi.sh).
+
+- **Disconnected** — shows **Connect Wallet**, or **Reconnect with `<Wallet>`**
+  when a previously used connector is remembered (see
+  [Session persistence](#session-persistence)). Clicking opens the AppKit modal.
+- **Connected** — shows the truncated address (click to open AppKit for account
+  and network actions) next to a **copy** button that writes the full public
+  address to the clipboard and briefly shows a checkmark.
+
+All tap targets are at least 44×44 px so the control is usable on touch devices.
+
+### Copy address
+
+The copy button uses the browser Clipboard API
+(`navigator.clipboard.writeText`). It copies the full, checksummed public
+address (never any private key or signature). Copying a public address is safe
+to share.
+
+## Session persistence
+
+Wallet sessions follow a _remember-the-method, expire-on-inactivity_ model.
+
+- **Remembered connector** — when a connection becomes active, the connector
+  label (for example `MetaMask` or `WalletConnect`) is stored in `localStorage`
+  under `trustledger:last-wallet` (see `src/lib/lastWallet.ts`). Only the
+  human-readable label is stored — never keys, signatures, or session tokens —
+  so it grants no access on its own and a reconnect always re-prompts the
+  wallet.
+- **Inactivity auto-logout** — after **10 minutes** of no user interaction the
+  wallet is disconnected automatically (`src/lib/useInactivityLogout.ts`,
+  mounted once in `src/components/Providers.tsx`). Pointer, keyboard, scroll,
+  and touch activity, or the tab regaining focus, resets the countdown. The
+  limit is the exported constant `INACTIVITY_LIMIT_MS`.
+- After logout or expiry, the connect button surfaces **Reconnect with
+  `<Wallet>`** for the remembered connector.
+
+This is a UX layer over wagmi's existing connection storage; it adds no auth
+surface and stores no signing material.
+
+## Configuration
+
+| Env var                                | Purpose                                                                                                                                         |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` | Reown/WalletConnect project ID. Required for relay wallets (Tangem, Phantom, mobile MetaMask via QR). Get one at <https://dashboard.reown.com>. |
+| `NEXT_PUBLIC_SITE_URL`                 | Origin advertised to wallets during pairing. `NEXT_PUBLIC_APP_URL` is accepted as an alias. On the client the live origin is always used.       |
+
+Without a real project ID, relay-based wallets cannot pair and the browser
+console logs a warning from `src/lib/wagmi.ts`. Injected wallets and Coinbase
+Wallet still work without the relay.
+
+Featured wallets and their WalletConnect registry IDs are defined in
+`src/lib/walletIds.ts`.
+
+## Mobile / Tangem manual test checklist
+
+Tangem connects over the WalletConnect relay and requires an NFC tap on a
+physical card, so it cannot be automated. Verify on a real phone:
+
+1. [ ] Confirm `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` is set for the deployment
+       under test (no console warning from `lib/wagmi.ts`).
+2. [ ] Open the site on a mobile browser and tap **Connect Wallet**.
+3. [ ] Choose **Tangem** in the AppKit modal; the Tangem app opens (or a QR /
+       deep link is shown).
+4. [ ] Approve the session in the Tangem app and tap the card when prompted.
+5. [ ] Confirm the browser returns to the site and shows your address.
+6. [ ] Tap the **copy** button and confirm the full address is on the clipboard.
+7. [ ] Perform a signing action (create a contract, or stake as a juror) and
+       confirm the Tangem prompt appears and the transaction completes.
+8. [ ] Leave the tab idle for 10 minutes and confirm the wallet auto-disconnects
+       and **Reconnect with Tangem** appears.
+
+Repeat steps 2–7 for Phantom and mobile MetaMask to cover the other relay
+wallets.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
     - Architecture: ARCHITECTURE.md
     - Contract Reference: CONTRACTS.md
     - Contributing: CONTRIBUTING.md
+    - Wallets: WALLETS.md
     - FAQ: FAQ.md
     - Deployment: DEPLOYMENT.md
     - Docker: DOCKER.md

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"node": "hardhat node",
 		"hardhat:deploy:local": "TS_NODE_PROJECT=tsconfig.hardhat.json hardhat run scripts/deploy.ts --network localhost",
 		"hardhat:deploy:sepolia": "TS_NODE_PROJECT=tsconfig.hardhat.json hardhat run scripts/deploy.ts --network sepolia",
+		"sync:frontend:env": "TS_NODE_PROJECT=tsconfig.hardhat.json hardhat run scripts/sync-frontend-env.ts",
 		"start:deploy:local": "npm run compile && (npm run node &) && sleep 2 && npm run hardhat:deploy:local",
 		"start:deploy:dry-run": "npm run foundry:build && npm run foundry:deploy:sepolia:dry-run",
 		"start:deploy:hardhat": "npm run compile && npm run hardhat:deploy:sepolia",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,6 +6,12 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { ethers } from "hardhat";
 import type { TrustLedger as TrustLedgerContract } from "../artifacts/typechain-types";
+import { syncFrontendEnv } from "./sync-frontend-env";
+
+// Hardhat's built-in local node chain ID. Only on a local chain do we mirror the
+// deployed addresses into src/.env.local; live deploys feed Vercel via the
+// GitHub Actions workflow instead.
+const HARDHAT_LOCAL_CHAIN_ID = 31337n;
 
 async function main(): Promise<void> {
 	// ethers.getSigners() returns all accounts configured in hardhat.config.ts for the
@@ -104,6 +110,14 @@ async function main(): Promise<void> {
 	mkdirSync(outDir, { recursive: true });
 	writeFileSync(resolve(outDir, "deployed-addresses.json"), JSON.stringify(addresses, null, 2));
 	console.log("\nAddresses written to artifacts/deployed-addresses.json");
+
+	// On the local node, mirror the addresses into src/.env.local so the Next.js
+	// dev server resolves the contracts (incl. ReputationRegistry) without a
+	// manual copy step. Skipped on live networks (Vercel is updated by CI).
+	const chainId = (await ethers.provider.getNetwork()).chainId;
+	if (chainId === HARDHAT_LOCAL_CHAIN_ID) {
+		syncFrontendEnv();
+	}
 }
 
 // Standard Node.js async error handling pattern.

--- a/scripts/sync-frontend-env.ts
+++ b/scripts/sync-frontend-env.ts
@@ -10,8 +10,22 @@
 // Run directly:    npx hardhat run scripts/sync-frontend-env.ts  (or via tsx/ts-node)
 // Run from deploy: imported and called by scripts/deploy.ts for local networks.
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+
+/**
+ * Reads a UTF-8 file, returning `null` if it does not exist. Uses a try/catch on
+ * the read itself (rather than a separate existsSync check) to avoid a
+ * time-of-check-to-time-of-use race between the existence check and the read.
+ */
+function readFileOrNull(path: string): string | null {
+	try {
+		return readFileSync(path, "utf8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+		throw err;
+	}
+}
 
 /** Maps the deployed-addresses.json keys to their NEXT_PUBLIC_* env var names. */
 const ENV_KEY_BY_CONTRACT: Record<string, string> = {
@@ -39,16 +53,17 @@ function upsertEnvLine(body: string, key: string, value: string): string {
  */
 export function syncFrontendEnv(): void {
 	const addressesPath = resolve(__dirname, "../artifacts/deployed-addresses.json");
-	if (!existsSync(addressesPath)) {
+	const addressesJson = readFileOrNull(addressesPath);
+	if (addressesJson === null) {
 		console.warn(
 			"sync-frontend-env: artifacts/deployed-addresses.json not found - run a deploy first.",
 		);
 		return;
 	}
 
-	const addresses = JSON.parse(readFileSync(addressesPath, "utf8")) as Record<string, string>;
+	const addresses = JSON.parse(addressesJson) as Record<string, string>;
 	const envPath = resolve(__dirname, "../src/.env.local");
-	let body = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+	let body = readFileOrNull(envPath) ?? "";
 
 	for (const [contract, envKey] of Object.entries(ENV_KEY_BY_CONTRACT)) {
 		const value = addresses[contract];

--- a/scripts/sync-frontend-env.ts
+++ b/scripts/sync-frontend-env.ts
@@ -1,0 +1,67 @@
+// scripts/sync-frontend-env.ts - sync deployed contract addresses into the
+// frontend's local env file so the Next.js dev server picks them up.
+//
+// The frontend reads contract addresses from NEXT_PUBLIC_* env vars (see
+// src/lib/wagmi.ts). In production the deploy workflow upserts these into Vercel;
+// for local development this script bridges artifacts/deployed-addresses.json
+// (written by scripts/deploy.ts) into src/.env.local. Without it the reputation
+// page shows "ReputationRegistry is not configured" after a fresh local deploy.
+//
+// Run directly:    npx hardhat run scripts/sync-frontend-env.ts  (or via tsx/ts-node)
+// Run from deploy: imported and called by scripts/deploy.ts for local networks.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/** Maps the deployed-addresses.json keys to their NEXT_PUBLIC_* env var names. */
+const ENV_KEY_BY_CONTRACT: Record<string, string> = {
+	TrustLedger: "NEXT_PUBLIC_TRUSTLEDGER_ADDRESS",
+	Arbitration: "NEXT_PUBLIC_ARBITRATION_ADDRESS",
+	JurorRegistry: "NEXT_PUBLIC_JUROR_REGISTRY_ADDRESS",
+	ReputationRegistry: "NEXT_PUBLIC_REPUTATION_REGISTRY_ADDRESS",
+};
+
+/** Upserts `key=value` into the `.env` file body, preserving all other lines. */
+function upsertEnvLine(body: string, key: string, value: string): string {
+	const line = `${key}=${value}`;
+	const pattern = new RegExp(`^${key}=.*$`, "m");
+	if (pattern.test(body)) {
+		return body.replace(pattern, line);
+	}
+	const trimmed = body.replace(/\s*$/, "");
+	return trimmed === "" ? `${line}\n` : `${trimmed}\n${line}\n`;
+}
+
+/**
+ * Reads artifacts/deployed-addresses.json and writes the four NEXT_PUBLIC_*
+ * contract-address keys into src/.env.local, leaving every other line intact.
+ * Idempotent: re-running overwrites only the managed keys.
+ */
+export function syncFrontendEnv(): void {
+	const addressesPath = resolve(__dirname, "../artifacts/deployed-addresses.json");
+	if (!existsSync(addressesPath)) {
+		console.warn(
+			"sync-frontend-env: artifacts/deployed-addresses.json not found - run a deploy first.",
+		);
+		return;
+	}
+
+	const addresses = JSON.parse(readFileSync(addressesPath, "utf8")) as Record<string, string>;
+	const envPath = resolve(__dirname, "../src/.env.local");
+	let body = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+
+	for (const [contract, envKey] of Object.entries(ENV_KEY_BY_CONTRACT)) {
+		const value = addresses[contract];
+		if (typeof value === "string" && value !== "") {
+			body = upsertEnvLine(body, envKey, value);
+		}
+	}
+
+	writeFileSync(envPath, body);
+	console.log("sync-frontend-env: updated src/.env.local with deployed contract addresses.");
+}
+
+// Allow running standalone: `npx hardhat run scripts/sync-frontend-env.ts`.
+if (require.main === module) {
+	syncFrontendEnv();
+}

--- a/src/app/arbitration/[id]/page.tsx
+++ b/src/app/arbitration/[id]/page.tsx
@@ -189,11 +189,22 @@ function RevealForm({ disputeId }: { disputeId: bigint }): React.JSX.Element {
 
 	const [pct, setPct] = useState(Number(storedPct));
 	const [salt, setSalt] = useState(storedSalt);
+	const [saltTouched, setSaltTouched] = useState(false);
 	const { writeContract, data: txHash, isPending, error } = useWriteContract();
 	const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
 
+	// revealVote takes a bytes32 salt: exactly 0x followed by 64 hex characters.
+	const saltError =
+		salt.trim() === ""
+			? "Salt is required."
+			: !/^0x[0-9a-fA-F]{64}$/.test(salt.trim())
+				? "Salt must be a 0x-prefixed 32-byte hex string (66 characters)."
+				: undefined;
+
 	function handleReveal(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
+		setSaltTouched(true);
+		if (saltError !== undefined) return;
 		writeContract({
 			address: ARBITRATION_ADDRESS,
 			abi: ARBITRATION_ABI,
@@ -238,9 +249,20 @@ function RevealForm({ disputeId }: { disputeId: bigint }): React.JSX.Element {
 					onChange={(e) => {
 						setSalt(e.target.value);
 					}}
+					onBlur={() => {
+						setSaltTouched(true);
+					}}
 					placeholder="0x…"
-					className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-xs font-mono text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+					aria-invalid={saltTouched && saltError !== undefined}
+					className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-xs font-mono text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:ring-2 ${
+						saltTouched && saltError !== undefined
+							? "border-red-500 dark:border-red-500 focus:ring-red-500"
+							: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+					}`}
 				/>
+				{saltTouched && saltError !== undefined && (
+					<p className="text-xs text-red-500 dark:text-red-400">{saltError}</p>
+				)}
 			</div>
 			{error !== null && (
 				<p className="text-xs text-red-500 dark:text-red-400">
@@ -249,7 +271,7 @@ function RevealForm({ disputeId }: { disputeId: bigint }): React.JSX.Element {
 			)}
 			<button
 				type="submit"
-				disabled={isPending || isConfirming || salt === ""}
+				disabled={isPending || isConfirming || saltError !== undefined}
 				className="px-4 py-2 text-sm rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-white font-semibold self-start transition-colors"
 			>
 				{isPending || isConfirming ? "Revealing…" : "Reveal Vote"}

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -9,49 +9,22 @@ import {
 	useWaitForTransactionReceipt,
 } from "wagmi";
 import { ConnectButton } from "@/components/ConnectButton";
+import { Field, Input, Select } from "@/components/Field";
 import { parseEther, keccak256, toBytes, parseEventLogs } from "viem";
 import { TRUSTLEDGER_ABI } from "@/lib/abi";
 import { TRUSTLEDGER_ADDRESS, getExplorerTxUrl } from "@/lib/wagmi";
 import { daysToSeconds } from "@/lib/utils";
+import {
+	validateContractUri,
+	validateEmail,
+	validateEthAddress,
+	validateEthAmount,
+	validateNumberInRange,
+	validateRequired,
+} from "@/lib/validation";
 import { uploadToPinata } from "@/lib/ipfs";
 import { encryptFile } from "@/lib/encryption";
 import type { ArweaveJWK } from "@/lib/arweave";
-
-function Field({
-	label,
-	hint,
-	children,
-}: {
-	label: string;
-	hint?: string;
-	children: React.ReactNode;
-}): React.JSX.Element {
-	return (
-		<div className="flex flex-col gap-1.5">
-			<label className="text-sm font-medium text-gray-700 dark:text-gray-200">{label}</label>
-			{children}
-			{hint !== undefined && <p className="text-xs text-gray-500">{hint}</p>}
-		</div>
-	);
-}
-
-function Input(props: React.InputHTMLAttributes<HTMLInputElement>): React.JSX.Element {
-	return (
-		<input
-			{...props}
-			className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
-		/>
-	);
-}
-
-function Select(props: React.SelectHTMLAttributes<HTMLSelectElement>): React.JSX.Element {
-	return (
-		<select
-			{...props}
-			className="rounded-lg bg-gray-100 dark:bg-gray-900 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
-		/>
-	);
-}
 
 type DocMode = "upload" | "manual";
 type UploadStatus = "idle" | "working" | "done" | "error";
@@ -107,6 +80,55 @@ export default function CreatePage(): React.JSX.Element {
 		setForm((f) => ({ ...f, [key]: value }));
 	}
 
+	// ── Field validation ────────────────────────────────────────────────────────
+	// Each field's error is computed from current state; it is only surfaced once
+	// the field has been blurred (touched) or the user has attempted to submit, so
+	// the form doesn't shout at the user before they've typed.
+	const [touched, setTouched] = useState<Partial<Record<string, boolean>>>({});
+	const [submitAttempted, setSubmitAttempted] = useState(false);
+
+	function markTouched(key: string): void {
+		setTouched((t) => ({ ...t, [key]: true }));
+	}
+
+	const fieldErrors = useMemo(
+		() => ({
+			freelancer: validateEthAddress(form.freelancer),
+			freelancerEmail: validateEmail(form.freelancerEmail),
+			amountEth: validateEthAmount(form.amountEth),
+			contractURI: docMode === "manual" ? validateContractUri(form.contractURI) : undefined,
+			estimatedDurationDays: validateNumberInRange(form.estimatedDurationDays, 1, 3650, {
+				integer: true,
+				unit: "days",
+			}),
+			bufferFactor: validateNumberInRange(form.bufferFactor, 1000, 100000, { integer: true }),
+			acceptanceWindowDays: validateNumberInRange(form.acceptanceWindowDays, 2, 3650, {
+				integer: true,
+				unit: "days",
+			}),
+			arbitrationFeePct: validateNumberInRange(form.arbitrationFeePct, 0, 50),
+			warrantyPeriodDays:
+				form.holdBack === "none"
+					? undefined
+					: validateNumberInRange(form.warrantyPeriodDays, 1, 3650, {
+							integer: true,
+							unit: "days",
+						}),
+			pinataJwt:
+				docMode === "upload" && selectedFile !== null
+					? validateRequired(pinataJwt, "Pinata JWT")
+					: undefined,
+			passphrase: encryptEnabled ? validateRequired(passphrase, "Passphrase") : undefined,
+		}),
+		[form, docMode, selectedFile, pinataJwt, encryptEnabled, passphrase],
+	);
+
+	function showError(key: keyof typeof fieldErrors): string | undefined {
+		return touched[key] === true || submitAttempted ? fieldErrors[key] : undefined;
+	}
+
+	const hasBlockingErrors = Object.values(fieldErrors).some((e) => e !== undefined);
+
 	// Pre-compute tx args whenever the form changes - fed into useSimulateContract so the
 	// transaction is validated on-chain before MetaMask opens. This prevents the "gas limit
 	// too high" symptom caused by gas estimation failing on a reverting transaction.
@@ -149,6 +171,8 @@ export default function CreatePage(): React.JSX.Element {
 
 	function handleSubmit(e: React.SyntheticEvent): void {
 		e.preventDefault();
+		setSubmitAttempted(true);
+		if (hasBlockingErrors) return;
 		if (simData?.request !== undefined) {
 			writeContract(simData.request);
 		}
@@ -348,6 +372,7 @@ export default function CreatePage(): React.JSX.Element {
 					<Field
 						label="Freelancer Address"
 						hint="The wallet that will receive payment on completion."
+						error={showError("freelancer")}
 					>
 						<Input
 							type="text"
@@ -356,6 +381,10 @@ export default function CreatePage(): React.JSX.Element {
 							onChange={(e) => {
 								set("freelancer", e.target.value);
 							}}
+							onBlur={() => {
+								markTouched("freelancer");
+							}}
+							error={showError("freelancer") !== undefined}
 							required
 							pattern="^0x[0-9a-fA-F]{40}$"
 						/>
@@ -364,6 +393,7 @@ export default function CreatePage(): React.JSX.Element {
 					<Field
 						label="Freelancer Email"
 						hint="A signed magic link will be sent here so the freelancer can accept via the web."
+						error={showError("freelancerEmail")}
 					>
 						<Input
 							type="email"
@@ -372,10 +402,18 @@ export default function CreatePage(): React.JSX.Element {
 							onChange={(e) => {
 								set("freelancerEmail", e.target.value);
 							}}
+							onBlur={() => {
+								markTouched("freelancerEmail");
+							}}
+							error={showError("freelancerEmail") !== undefined}
 						/>
 					</Field>
 
-					<Field label="Escrow Amount (ETH)" hint="Total ETH to lock in escrow.">
+					<Field
+						label="Escrow Amount (ETH)"
+						hint="Total ETH to lock in escrow."
+						error={showError("amountEth")}
+					>
 						<Input
 							type="number"
 							placeholder="0.5"
@@ -385,6 +423,10 @@ export default function CreatePage(): React.JSX.Element {
 							onChange={(e) => {
 								set("amountEth", e.target.value);
 							}}
+							onBlur={() => {
+								markTouched("amountEth");
+							}}
+							error={showError("amountEth") !== undefined}
 							required
 						/>
 					</Field>
@@ -461,6 +503,7 @@ export default function CreatePage(): React.JSX.Element {
 								<Field
 									label="Passphrase"
 									hint="Share this with the other party via a separate secure channel. You cannot decrypt without it."
+									error={showError("passphrase")}
 								>
 									<Input
 										type="password"
@@ -469,6 +512,10 @@ export default function CreatePage(): React.JSX.Element {
 										onChange={(e) => {
 											setPassphrase(e.target.value);
 										}}
+										onBlur={() => {
+											markTouched("passphrase");
+										}}
+										error={showError("passphrase") !== undefined}
 									/>
 								</Field>
 							)}
@@ -476,7 +523,11 @@ export default function CreatePage(): React.JSX.Element {
 							{/* Pinata JWT - shown if not baked in via env */}
 							{(process.env["NEXT_PUBLIC_PINATA_JWT"] === undefined ||
 								process.env["NEXT_PUBLIC_PINATA_JWT"] === "") && (
-								<Field label="Pinata JWT">
+								<Field
+									label="Pinata JWT"
+									hint="Required to upload the document to IPFS."
+									error={showError("pinataJwt")}
+								>
 									<Input
 										type="password"
 										placeholder="eyJhbGciOiJIUzI1NiIs…"
@@ -484,6 +535,10 @@ export default function CreatePage(): React.JSX.Element {
 										onChange={(e) => {
 											setPinataJwt(e.target.value);
 										}}
+										onBlur={() => {
+											markTouched("pinataJwt");
+										}}
+										error={showError("pinataJwt") !== undefined}
 									/>
 								</Field>
 							)}
@@ -586,6 +641,7 @@ export default function CreatePage(): React.JSX.Element {
 						<Field
 							label="Contract Document URI"
 							hint="IPFS link or URL to the off-chain agreement. A hash of this is stored on-chain."
+							error={showError("contractURI")}
 						>
 							<Input
 								type="text"
@@ -594,6 +650,10 @@ export default function CreatePage(): React.JSX.Element {
 								onChange={(e) => {
 									set("contractURI", e.target.value);
 								}}
+								onBlur={() => {
+									markTouched("contractURI");
+								}}
+								error={showError("contractURI") !== undefined}
 							/>
 						</Field>
 					)}
@@ -607,6 +667,7 @@ export default function CreatePage(): React.JSX.Element {
 						<Field
 							label="Estimated Duration (days)"
 							hint="How long the project should take."
+							error={showError("estimatedDurationDays")}
 						>
 							<Input
 								type="number"
@@ -615,6 +676,10 @@ export default function CreatePage(): React.JSX.Element {
 								onChange={(e) => {
 									set("estimatedDurationDays", e.target.value);
 								}}
+								onBlur={() => {
+									markTouched("estimatedDurationDays");
+								}}
+								error={showError("estimatedDurationDays") !== undefined}
 								required
 							/>
 						</Field>
@@ -622,6 +687,7 @@ export default function CreatePage(): React.JSX.Element {
 						<Field
 							label="Buffer Factor"
 							hint="Project deadline = duration × buffer / 1000. E.g. 1200 = 1.2× buffer."
+							error={showError("bufferFactor")}
 						>
 							<Input
 								type="number"
@@ -631,6 +697,10 @@ export default function CreatePage(): React.JSX.Element {
 								onChange={(e) => {
 									set("bufferFactor", e.target.value);
 								}}
+								onBlur={() => {
+									markTouched("bufferFactor");
+								}}
+								error={showError("bufferFactor") !== undefined}
 								required
 							/>
 						</Field>
@@ -639,6 +709,7 @@ export default function CreatePage(): React.JSX.Element {
 					<Field
 						label="Acceptance Window (days)"
 						hint="How long you have to review submitted work. Minimum 2 days."
+						error={showError("acceptanceWindowDays")}
 					>
 						<Input
 							type="number"
@@ -647,6 +718,10 @@ export default function CreatePage(): React.JSX.Element {
 							onChange={(e) => {
 								set("acceptanceWindowDays", e.target.value);
 							}}
+							onBlur={() => {
+								markTouched("acceptanceWindowDays");
+							}}
+							error={showError("acceptanceWindowDays") !== undefined}
 							required
 						/>
 					</Field>
@@ -661,6 +736,7 @@ export default function CreatePage(): React.JSX.Element {
 					<Field
 						label="Arbitration Fee (%)"
 						hint="Percentage of escrow set aside for jurors if a dispute is opened (0-50%)."
+						error={showError("arbitrationFeePct")}
 					>
 						<Input
 							type="number"
@@ -671,6 +747,10 @@ export default function CreatePage(): React.JSX.Element {
 							onChange={(e) => {
 								set("arbitrationFeePct", e.target.value);
 							}}
+							onBlur={() => {
+								markTouched("arbitrationFeePct");
+							}}
+							error={showError("arbitrationFeePct") !== undefined}
 							required
 						/>
 					</Field>
@@ -696,6 +776,7 @@ export default function CreatePage(): React.JSX.Element {
 						<Field
 							label="Warranty Period (days)"
 							hint="How long the hold-back is locked after work is approved."
+							error={showError("warrantyPeriodDays")}
 						>
 							<Input
 								type="number"
@@ -704,6 +785,10 @@ export default function CreatePage(): React.JSX.Element {
 								onChange={(e) => {
 									set("warrantyPeriodDays", e.target.value);
 								}}
+								onBlur={() => {
+									markTouched("warrantyPeriodDays");
+								}}
+								error={showError("warrantyPeriodDays") !== undefined}
 								required
 							/>
 						</Field>
@@ -766,6 +851,7 @@ export default function CreatePage(): React.JSX.Element {
 					disabled={
 						isPending ||
 						isConfirming ||
+						hasBlockingErrors ||
 						(txArgs !== null && simData?.request === undefined && simError === null)
 					}
 					className="px-6 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold transition-colors"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { formatEther, keccak256, toBytes } from "viem";
 import { TRUSTLEDGER_ABI, STATUS_LABELS } from "@/lib/abi";
 import { REPUTATION_REGISTRY_ADDRESS, TRUSTLEDGER_ADDRESS } from "@/lib/wagmi";
 import { formatAddress, formatDeadline, resolveDocUrl, STATUS_COLORS } from "@/lib/utils";
+import { validateRequired, validateRequiredUri, validateScore } from "@/lib/validation";
 import { decryptFile } from "@/lib/encryption";
 import type { Contract } from "@/types";
 import Link from "next/link";
@@ -62,6 +63,7 @@ function ActionButton({
 // The registry is optional — if it isn't deployed (zero address), the form hides entirely.
 function RatingForm({ contractId }: { contractId: bigint }): React.JSX.Element {
 	const [score, setScore] = useState("80");
+	const [touched, setTouched] = useState(false);
 	const { writeContract, data: txHash, isPending, error, reset } = useWriteContract();
 	const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
 
@@ -70,10 +72,13 @@ function RatingForm({ contractId }: { contractId: bigint }): React.JSX.Element {
 	const registryDeployed =
 		REPUTATION_REGISTRY_ADDRESS !== "0x0000000000000000000000000000000000000000";
 
+	const scoreError = validateScore(score);
+
 	function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
+		setTouched(true);
 		const parsed = Number(score);
-		if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100) return;
+		if (scoreError !== undefined || !Number.isInteger(parsed)) return;
 		writeContract({
 			address: TRUSTLEDGER_ADDRESS,
 			abi: TRUSTLEDGER_ABI,
@@ -114,16 +119,27 @@ function RatingForm({ contractId }: { contractId: bigint }): React.JSX.Element {
 					onChange={(e) => {
 						setScore(e.target.value);
 					}}
-					className="w-20 rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+					onBlur={() => {
+						setTouched(true);
+					}}
+					aria-invalid={touched && scoreError !== undefined}
+					className={`w-20 rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 ${
+						touched && scoreError !== undefined
+							? "border-red-500 dark:border-red-500 focus:ring-red-500"
+							: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+					}`}
 				/>
 				<button
 					type="submit"
-					disabled={isPending || isConfirming}
+					disabled={isPending || isConfirming || scoreError !== undefined}
 					className="px-3 py-1.5 text-xs rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-white font-medium transition-colors"
 				>
 					{isPending || isConfirming ? "…" : "Submit rating"}
 				</button>
 			</div>
+			{touched && scoreError !== undefined && (
+				<p className="text-xs text-red-500 dark:text-red-400">{scoreError}</p>
+			)}
 			{error !== null && (
 				<p className="text-xs text-red-500 dark:text-red-400">
 					{(error as { shortMessage?: string }).shortMessage ?? error.message}
@@ -140,13 +156,17 @@ function RatingForm({ contractId }: { contractId: bigint }): React.JSX.Element {
 // the on-chain hash no longer matches, proving the deliverable was altered after submission.
 function SubmitWorkForm({ contractId }: { contractId: bigint }): React.JSX.Element {
 	const [uri, setUri] = useState("");
+	const [touched, setTouched] = useState(false);
 	const { writeContract, data: txHash, isPending, error } = useWriteContract();
 	const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
 
+	const uriError = validateRequiredUri(uri);
+
 	function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
+		setTouched(true);
 		const trimmed = uri.trim();
-		if (trimmed === "") return;
+		if (uriError !== undefined) return;
 		writeContract({
 			address: TRUSTLEDGER_ADDRESS,
 			abi: TRUSTLEDGER_ABI,
@@ -171,9 +191,20 @@ function SubmitWorkForm({ contractId }: { contractId: bigint }): React.JSX.Eleme
 				onChange={(e) => {
 					setUri(e.target.value);
 				}}
+				onBlur={() => {
+					setTouched(true);
+				}}
 				required
-				className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition"
+				aria-invalid={touched && uriError !== undefined}
+				className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:border-transparent transition ${
+					touched && uriError !== undefined
+						? "border-red-500 dark:border-red-500 focus:ring-red-500"
+						: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+				}`}
 			/>
+			{touched && uriError !== undefined && (
+				<p className="text-xs text-red-500 dark:text-red-400">{uriError}</p>
+			)}
 			{error !== null && (
 				<p className="text-xs text-red-500 dark:text-red-400">
 					{(error as { shortMessage?: string }).shortMessage ?? error.message}
@@ -181,7 +212,7 @@ function SubmitWorkForm({ contractId }: { contractId: bigint }): React.JSX.Eleme
 			)}
 			<button
 				type="submit"
-				disabled={isPending || isConfirming || uri.trim() === ""}
+				disabled={isPending || isConfirming || uriError !== undefined}
 				className="px-3 py-1.5 text-xs rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white font-medium transition-colors"
 			>
 				{isPending || isConfirming ? "Submitting…" : "Submit Work"}
@@ -209,6 +240,12 @@ function DecryptDocumentForm({
 	const [filename, setFilename] = useState("decrypted-document");
 	const [status, setStatus] = useState<DecryptStatus>("idle");
 	const [errorMsg, setErrorMsg] = useState<string | null>(null);
+	const [passphraseTouched, setPassphraseTouched] = useState(false);
+	const [bundleTouched, setBundleTouched] = useState(false);
+
+	const passphraseError = validateRequired(passphrase, "Passphrase");
+	const bundleError =
+		mode === "paste" ? validateRequired(pastedBundle, "Encrypted bundle") : undefined;
 
 	async function handleDecrypt(): Promise<void> {
 		setStatus("working");
@@ -289,26 +326,52 @@ function DecryptDocumentForm({
 					<span className="font-mono text-gray-600 dark:text-gray-400">{gatewayUrl}</span>
 				</p>
 			) : (
-				<textarea
-					rows={4}
-					placeholder={'{"v":1,"alg":"AES-256-GCM",…}'}
-					value={pastedBundle}
-					onChange={(e) => {
-						setPastedBundle(e.target.value);
-					}}
-					className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-xs text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
-				/>
+				<div className="flex flex-col gap-1">
+					<textarea
+						rows={4}
+						placeholder={'{"v":1,"alg":"AES-256-GCM",…}'}
+						value={pastedBundle}
+						onChange={(e) => {
+							setPastedBundle(e.target.value);
+						}}
+						onBlur={() => {
+							setBundleTouched(true);
+						}}
+						aria-invalid={bundleTouched && bundleError !== undefined}
+						className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-xs text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 font-mono focus:outline-none focus:ring-2 resize-none ${
+							bundleTouched && bundleError !== undefined
+								? "border-red-500 dark:border-red-500 focus:ring-red-500"
+								: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+						}`}
+					/>
+					{bundleTouched && bundleError !== undefined && (
+						<p className="text-xs text-red-500 dark:text-red-400">{bundleError}</p>
+					)}
+				</div>
 			)}
 
-			<input
-				type="password"
-				placeholder="Passphrase"
-				value={passphrase}
-				onChange={(e) => {
-					setPassphrase(e.target.value);
-				}}
-				className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-			/>
+			<div className="flex flex-col gap-1">
+				<input
+					type="password"
+					placeholder="Passphrase"
+					value={passphrase}
+					onChange={(e) => {
+						setPassphrase(e.target.value);
+					}}
+					onBlur={() => {
+						setPassphraseTouched(true);
+					}}
+					aria-invalid={passphraseTouched && passphraseError !== undefined}
+					className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 ${
+						passphraseTouched && passphraseError !== undefined
+							? "border-red-500 dark:border-red-500 focus:ring-red-500"
+							: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+					}`}
+				/>
+				{passphraseTouched && passphraseError !== undefined && (
+					<p className="text-xs text-red-500 dark:text-red-400">{passphraseError}</p>
+				)}
+			</div>
 
 			<input
 				type="text"

--- a/src/app/juror/page.tsx
+++ b/src/app/juror/page.tsx
@@ -7,6 +7,17 @@ import { formatEther, parseEther } from "viem";
 import { JUROR_REGISTRY_ABI } from "@/lib/abi";
 import { JUROR_REGISTRY_ADDRESS } from "@/lib/wagmi";
 import { formatAddress } from "@/lib/utils";
+import { validateEthAmount } from "@/lib/validation";
+
+// Minimum stake to register or top up, in ETH (mirrors the JurorRegistry contract).
+const MIN_STAKE_ETH = 0.01;
+
+/** Validates a juror stake amount: a positive ETH value of at least `minEth`. */
+function validateStake(value: string, minEth: number, maxEth?: number): string | undefined {
+	const base = validateEthAmount(value, maxEth);
+	if (base !== undefined) return base;
+	return Number(value) < minEth ? `Minimum is ${minEth.toString()} ETH.` : undefined;
+}
 
 const SEVEN_DAYS_S = 7 * 24 * 60 * 60;
 
@@ -153,11 +164,16 @@ function StatusCard({ address }: { address: `0x${string}` }): React.JSX.Element 
 
 function RegisterForm(): React.JSX.Element {
 	const [ethAmount, setEthAmount] = useState("0.01");
+	const [touched, setTouched] = useState(false);
 	const { writeContract, data: txHash, isPending, error, reset } = useWriteContract();
 	const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
 
+	const amountError = validateStake(ethAmount, MIN_STAKE_ETH);
+
 	function handleRegister(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
+		setTouched(true);
+		if (amountError !== undefined) return;
 		let value: bigint;
 		try {
 			value = parseEther(ethAmount);
@@ -207,10 +223,21 @@ function RegisterForm(): React.JSX.Element {
 						onChange={(e) => {
 							setEthAmount(e.target.value);
 						}}
-						className="w-36 rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+						onBlur={() => {
+							setTouched(true);
+						}}
+						aria-invalid={touched && amountError !== undefined}
+						className={`w-36 rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 ${
+							touched && amountError !== undefined
+								? "border-red-500 dark:border-red-500 focus:ring-red-500"
+								: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+						}`}
 					/>
 					<span className="text-sm text-gray-500 dark:text-gray-400">ETH</span>
 				</div>
+				{touched && amountError !== undefined && (
+					<p className="text-xs text-red-500 dark:text-red-400">{amountError}</p>
+				)}
 				{error !== null && (
 					<p className="text-xs text-red-500 dark:text-red-400">
 						{(error as { shortMessage?: string }).shortMessage ?? error.message}
@@ -218,7 +245,7 @@ function RegisterForm(): React.JSX.Element {
 				)}
 				<button
 					type="submit"
-					disabled={isPending || isConfirming}
+					disabled={isPending || isConfirming || amountError !== undefined}
 					className="px-4 py-2 text-sm rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white font-semibold transition-colors self-start"
 				>
 					{isPending || isConfirming ? "Registering…" : "Register"}
@@ -231,12 +258,14 @@ function RegisterForm(): React.JSX.Element {
 function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.Element {
 	const [addAmount, setAddAmount] = useState("0.01");
 	const [unstakeAmount, setUnstakeAmount] = useState("");
+	const [addTouched, setAddTouched] = useState(false);
+	const [unstakeTouched, setUnstakeTouched] = useState(false);
 
 	const {
 		writeContract: writeAdd,
 		data: addHash,
 		isPending: addPending,
-		error: addError,
+		error: writeAddError,
 	} = useWriteContract();
 	const { isLoading: addConfirming } = useWaitForTransactionReceipt({ hash: addHash });
 
@@ -244,7 +273,7 @@ function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.El
 		writeContract: writeUnstake,
 		data: unstakeHash,
 		isPending: unstakePending,
-		error: unstakeError,
+		error: writeUnstakeError,
 	} = useWriteContract();
 	const { isLoading: unstakeConfirming } = useWaitForTransactionReceipt({ hash: unstakeHash });
 
@@ -256,10 +285,17 @@ function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.El
 	});
 
 	const isRegistered = juror?.active === true || (juror?.stake ?? 0n) > 0n;
+
+	const maxUnstakeEth = juror !== undefined ? Number(formatEther(juror.stake)) : undefined;
+	const addError = validateStake(addAmount, 0.001);
+	const unstakeError = validateStake(unstakeAmount, 0.001, maxUnstakeEth);
+
 	if (!isRegistered) return <></>;
 
 	function handleAdd(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
+		setAddTouched(true);
+		if (addError !== undefined) return;
 		let value: bigint;
 		try {
 			value = parseEther(addAmount);
@@ -276,6 +312,8 @@ function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.El
 
 	function handleUnstake(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
+		setUnstakeTouched(true);
+		if (unstakeError !== undefined) return;
 		let amount: bigint;
 		try {
 			amount = parseEther(unstakeAmount);
@@ -305,20 +343,32 @@ function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.El
 						onChange={(e) => {
 							setAddAmount(e.target.value);
 						}}
-						className="w-36 rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+						onBlur={() => {
+							setAddTouched(true);
+						}}
+						aria-invalid={addTouched && addError !== undefined}
+						className={`w-36 rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 ${
+							addTouched && addError !== undefined
+								? "border-red-500 dark:border-red-500 focus:ring-red-500"
+								: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+						}`}
 					/>
 					<span className="text-sm text-gray-500 dark:text-gray-400">ETH</span>
 					<button
 						type="submit"
-						disabled={addPending || addConfirming}
+						disabled={addPending || addConfirming || addError !== undefined}
 						className="px-3 py-1.5 text-xs rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 text-white font-medium transition-colors"
 					>
 						{addPending || addConfirming ? "…" : "Add"}
 					</button>
 				</div>
-				{addError !== null && (
+				{addTouched && addError !== undefined && (
+					<p className="text-xs text-red-500 dark:text-red-400">{addError}</p>
+				)}
+				{writeAddError !== null && (
 					<p className="text-xs text-red-500 dark:text-red-400">
-						{(addError as { shortMessage?: string }).shortMessage ?? addError.message}
+						{(writeAddError as { shortMessage?: string }).shortMessage ??
+							writeAddError.message}
 					</p>
 				)}
 			</form>
@@ -337,22 +387,33 @@ function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.El
 						onChange={(e) => {
 							setUnstakeAmount(e.target.value);
 						}}
+						onBlur={() => {
+							setUnstakeTouched(true);
+						}}
 						placeholder="0.01"
-						className="w-36 rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+						aria-invalid={unstakeTouched && unstakeError !== undefined}
+						className={`w-36 rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 ${
+							unstakeTouched && unstakeError !== undefined
+								? "border-red-500 dark:border-red-500 focus:ring-red-500"
+								: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+						}`}
 					/>
 					<span className="text-sm text-gray-500 dark:text-gray-400">ETH</span>
 					<button
 						type="submit"
-						disabled={unstakePending || unstakeConfirming}
+						disabled={unstakePending || unstakeConfirming || unstakeError !== undefined}
 						className="px-3 py-1.5 text-xs rounded-lg bg-red-700 hover:bg-red-600 disabled:opacity-40 text-white font-medium transition-colors"
 					>
 						{unstakePending || unstakeConfirming ? "…" : "Unstake"}
 					</button>
 				</div>
-				{unstakeError !== null && (
+				{unstakeTouched && unstakeError !== undefined && (
+					<p className="text-xs text-red-500 dark:text-red-400">{unstakeError}</p>
+				)}
+				{writeUnstakeError !== null && (
 					<p className="text-xs text-red-500 dark:text-red-400">
-						{(unstakeError as { shortMessage?: string }).shortMessage ??
-							unstakeError.message}
+						{(writeUnstakeError as { shortMessage?: string }).shortMessage ??
+							writeUnstakeError.message}
 					</p>
 				)}
 			</form>

--- a/src/app/reputation/page.tsx
+++ b/src/app/reputation/page.tsx
@@ -7,6 +7,7 @@ import { isAddress, parseAbiItem } from "viem";
 import { REPUTATION_REGISTRY_ABI } from "@/lib/abi";
 import { REPUTATION_REGISTRY_ADDRESS, TRUSTLEDGER_ADDRESS } from "@/lib/wagmi";
 import { formatAddress } from "@/lib/utils";
+import { validateEthAddress } from "@/lib/validation";
 import type { ReputationHistoryEntry as HistoryEntry } from "@/types";
 
 const RATED_EVENT = parseAbiItem("event Rated(address indexed user, uint8 indexed score)");
@@ -325,11 +326,14 @@ export default function ReputationPage(): React.JSX.Element {
 	function handleLookup(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
 		const trimmed = input.trim();
-		if (!isAddress(trimmed)) {
-			setInputError("Enter a valid Ethereum address (0x…).");
+		const error = validateEthAddress(trimmed);
+		if (error !== undefined) {
+			setInputError(error);
 			setLookupAddress(undefined);
 			return;
 		}
+		// validateEthAddress guarantees a valid address here; narrow the type.
+		if (!isAddress(trimmed)) return;
 		setInputError(undefined);
 		setLookupAddress(trimmed);
 	}
@@ -364,7 +368,12 @@ export default function ReputationPage(): React.JSX.Element {
 					onChange={(e) => {
 						setInput(e.target.value);
 					}}
-					className="rounded-lg bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm font-mono text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+					aria-invalid={inputError !== undefined}
+					className={`rounded-lg bg-white dark:bg-white/5 border px-3 py-2 text-sm font-mono text-gray-900 dark:text-white focus:outline-none focus:ring-2 ${
+						inputError !== undefined
+							? "border-red-500 dark:border-red-500 focus:ring-red-500"
+							: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+					}`}
 				/>
 				{inputError !== undefined && (
 					<p className="text-xs text-red-500 dark:text-red-400">{inputError}</p>

--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -1,31 +1,148 @@
 "use client";
 
-import { useAppKit, useAppKitAccount } from "@reown/appkit/react";
+import { useAppKit } from "@reown/appkit/react";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { useAccount } from "wagmi";
+import { getLastWallet, setLastWallet } from "@/lib/lastWallet";
+import { formatAddress } from "@/lib/utils";
+
+/** Clipboard "copy" glyph. */
+function CopyIcon(): React.JSX.Element {
+	return (
+		<svg
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+			<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+		</svg>
+	);
+}
+
+/** Checkmark glyph shown briefly after a successful copy. */
+function CheckIcon(): React.JSX.Element {
+	return (
+		<svg
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M20 6 9 17l-5-5" />
+		</svg>
+	);
+}
+
+const BUTTON_CLASS =
+	"inline-flex items-center justify-center min-h-[44px] rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500";
+
+// Hydration-safe "are we on the client yet?" flag. useSyncExternalStore returns
+// the server snapshot (false) during SSR and the first client render, then the
+// client snapshot (true) afterwards - without a setState-in-effect mounted flag.
+const subscribeNoop = (): (() => void) => (): void => undefined;
+function useMounted(): boolean {
+	return useSyncExternalStore(
+		subscribeNoop,
+		() => true,
+		() => false,
+	);
+}
 
 /**
- * App-wide wallet connect button backed by Reown AppKit.
+ * App-wide wallet control backed by Reown AppKit + wagmi.
  *
- * Renders "Connect Wallet" when disconnected and a truncated address when
- * connected; clicking opens the AppKit modal (account + network management when
- * connected, wallet picker otherwise). Replaces RainbowKit's `<ConnectButton>`.
+ * - Disconnected: a "Connect Wallet" button (or "Reconnect with <Wallet>" when a
+ *   previously used connector is remembered, see {@link getLastWallet}) that opens
+ *   the AppKit modal.
+ * - Connected: the truncated address (opens AppKit for account/network actions)
+ *   plus a copy-to-clipboard button for the full public address.
+ *
+ * A `mounted` gate ensures the first client render matches the server render
+ * ("Connect Wallet"), avoiding the React #418 hydration mismatch that occurred
+ * when wagmi rehydrated `isConnected` from storage before hydration completed.
  */
 export function ConnectButton(): React.JSX.Element {
 	const { open } = useAppKit();
-	const { address, isConnected } = useAppKitAccount();
+	const { address, isConnected, connector } = useAccount();
 
+	const mounted = useMounted();
+	const [copied, setCopied] = useState(false);
+
+	// Persist the connector label (localStorage only - no React state) whenever a
+	// connection is active, so the reconnect hint survives logout / session expiry.
+	useEffect(() => {
+		const name = connector?.name;
+		if (isConnected && name !== undefined && name !== "") {
+			setLastWallet(name);
+		}
+	}, [isConnected, connector]);
+
+	function openModal(): void {
+		void open();
+	}
+
+	// Until mounted, render the deterministic server markup to avoid #418.
+	if (!mounted) {
+		return (
+			<button type="button" onClick={openModal} className={BUTTON_CLASS}>
+				Connect Wallet
+			</button>
+		);
+	}
+
+	if (isConnected && address !== undefined) {
+		const copyAddress = (): void => {
+			void navigator.clipboard.writeText(address).then(() => {
+				setCopied(true);
+				setTimeout(() => {
+					setCopied(false);
+				}, 1500);
+			});
+		};
+
+		return (
+			<div className="inline-flex items-stretch overflow-hidden rounded-lg bg-indigo-600 text-white">
+				<button
+					type="button"
+					onClick={openModal}
+					className="inline-flex items-center min-h-[44px] px-4 py-2 text-sm font-medium font-mono transition-colors hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+				>
+					{formatAddress(address)}
+				</button>
+				<button
+					type="button"
+					onClick={copyAddress}
+					aria-label={copied ? "Address copied" : "Copy wallet address"}
+					title={copied ? "Copied!" : "Copy address"}
+					className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] border-l border-white/20 px-3 transition-colors hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+				>
+					{copied ? <CheckIcon /> : <CopyIcon />}
+				</button>
+			</div>
+		);
+	}
+
+	// Reached only when mounted, so reading localStorage here is client-safe.
+	const remembered = getLastWallet();
 	const label =
-		isConnected && address !== undefined
-			? `${address.slice(0, 6)}…${address.slice(-4)}`
+		remembered !== null && remembered !== ""
+			? `Reconnect with ${remembered}`
 			: "Connect Wallet";
 
 	return (
-		<button
-			type="button"
-			onClick={() => {
-				void open();
-			}}
-			className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-		>
+		<button type="button" onClick={openModal} className={BUTTON_CLASS}>
 			{label}
 		</button>
 	);

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useId } from "react";
+
+/**
+ * Shared form primitives with built-in inline validation display.
+ *
+ * `Field` wraps a labelled control and renders a red error message (explaining
+ * why the value is invalid and what is accepted) when `error` is set, otherwise
+ * the muted `hint`. `Input`, `Select`, and `TextArea` accept an `error` boolean
+ * that applies the red border treatment and sets `aria-invalid`.
+ *
+ * Example:
+ *   <Field label="Amount (ETH)" hint="Held in escrow." error={amountError}>
+ *     <Input type="number" error={amountError !== undefined} value={amount} … />
+ *   </Field>
+ */
+
+const BASE_INPUT_CLASS =
+	"rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:border-transparent transition";
+const INPUT_BG = "bg-gray-50 dark:bg-white/5";
+const SELECT_BG = "bg-gray-100 dark:bg-gray-900";
+const VALID_BORDER = "border border-gray-200 dark:border-white/10 focus:ring-indigo-500";
+const ERROR_BORDER = "border border-red-500 dark:border-red-500 focus:ring-red-500";
+
+function controlClass(bg: string, error: boolean): string {
+	return `${BASE_INPUT_CLASS} ${bg} ${error ? ERROR_BORDER : VALID_BORDER}`;
+}
+
+interface FieldProps {
+	label: string;
+	hint?: string | undefined;
+	/** Error message to show in red below the control; hides the hint when set. */
+	error?: string | undefined;
+	children: React.ReactNode;
+}
+
+export function Field({ label, hint, error, children }: FieldProps): React.JSX.Element {
+	const hasError = error !== undefined && error !== "";
+	const hasHint = hint !== undefined && hint !== "";
+	return (
+		<div className="flex flex-col gap-1.5">
+			<label className="text-sm font-medium text-gray-700 dark:text-gray-200">{label}</label>
+			{children}
+			{hasError ? (
+				<p className="text-xs text-red-500 dark:text-red-400" role="alert">
+					{error}
+				</p>
+			) : hasHint ? (
+				<p className="text-xs text-gray-500">{hint}</p>
+			) : null}
+		</div>
+	);
+}
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement> & { error?: boolean };
+
+export function Input({ error = false, className, ...props }: InputProps): React.JSX.Element {
+	const id = useId();
+	return (
+		<input
+			id={props.id ?? id}
+			aria-invalid={error}
+			{...props}
+			className={`${controlClass(INPUT_BG, error)}${className !== undefined && className !== "" ? ` ${className}` : ""}`}
+		/>
+	);
+}
+
+type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & { error?: boolean };
+
+export function Select({ error = false, className, ...props }: SelectProps): React.JSX.Element {
+	return (
+		<select
+			aria-invalid={error}
+			{...props}
+			className={`${controlClass(SELECT_BG, error)}${className !== undefined && className !== "" ? ` ${className}` : ""}`}
+		/>
+	);
+}
+
+type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & { error?: boolean };
+
+export function TextArea({ error = false, className, ...props }: TextAreaProps): React.JSX.Element {
+	return (
+		<textarea
+			aria-invalid={error}
+			{...props}
+			className={`${controlClass(INPUT_BG, error)}${className !== undefined && className !== "" ? ` ${className}` : ""}`}
+		/>
+	);
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider, useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { WagmiProvider } from "wagmi";
 import { config } from "@/lib/wagmi";
+import { useInactivityLogout } from "@/lib/useInactivityLogout";
 
 /**
  * Keeps the AppKit modal's light/dark mode in sync with next-themes.
@@ -24,6 +25,15 @@ function AppKitThemeSync(): null {
 	return null;
 }
 
+/**
+ * Drives the app-wide inactivity auto-logout. Renders nothing; lives inside
+ * `<WagmiProvider>` so the wagmi hooks it relies on are available.
+ */
+function InactivityWatcher(): null {
+	useInactivityLogout();
+	return null;
+}
+
 export function Providers({ children }: { children: React.ReactNode }): React.JSX.Element {
 	const [queryClient] = useState(() => new QueryClient());
 
@@ -37,6 +47,7 @@ export function Providers({ children }: { children: React.ReactNode }): React.JS
 			<WagmiProvider config={config}>
 				<QueryClientProvider client={queryClient}>
 					<AppKitThemeSync />
+					<InactivityWatcher />
 					{children}
 				</QueryClientProvider>
 			</WagmiProvider>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -43,7 +43,10 @@ function MoonIcon(): React.JSX.Element {
 export function ThemeToggle(): React.JSX.Element {
 	const { resolvedTheme, setTheme } = useTheme();
 
-	// resolvedTheme is undefined during SSR - render placeholder to avoid hydration mismatch
+	// resolvedTheme is undefined on the server and on the first client render
+	// (before next-themes mounts), so both render this same-size placeholder -
+	// keeping markup identical across hydration (avoids React #418) without a
+	// setState-in-effect mounted flag.
 	if (resolvedTheme === undefined) return <div className="w-9 h-9" />;
 
 	const isDark = resolvedTheme === "dark";

--- a/src/lib/lastWallet.ts
+++ b/src/lib/lastWallet.ts
@@ -1,0 +1,44 @@
+/**
+ * Persists the *label* of the most recently used wallet connector so the connect
+ * button can offer a one-tap "Reconnect with <Wallet>" after a logout or session
+ * expiry.
+ *
+ * Security note: this stores only the human-readable connector name (e.g.
+ * "MetaMask", "WalletConnect") — never a private key, signature, session token,
+ * or any authorization material. It is a pure UX convenience layered on top of
+ * wagmi's existing connection storage and grants no access on its own; a
+ * reconnect always re-prompts the underlying wallet.
+ */
+
+const LAST_WALLET_KEY = "trustledger:last-wallet";
+
+/** Returns the remembered connector label, or `null` when none is stored. */
+export function getLastWallet(): string | null {
+	if (typeof window === "undefined") return null;
+	try {
+		return window.localStorage.getItem(LAST_WALLET_KEY);
+	} catch {
+		// localStorage can throw in private-mode / sandboxed contexts.
+		return null;
+	}
+}
+
+/** Remembers `name` as the most recently used connector label. */
+export function setLastWallet(name: string): void {
+	if (typeof window === "undefined" || name === "") return;
+	try {
+		window.localStorage.setItem(LAST_WALLET_KEY, name);
+	} catch {
+		// Ignore storage failures - the reconnect hint is best-effort.
+	}
+}
+
+/** Forgets the remembered connector label. */
+export function clearLastWallet(): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.removeItem(LAST_WALLET_KEY);
+	} catch {
+		// Ignore storage failures.
+	}
+}

--- a/src/lib/useInactivityLogout.ts
+++ b/src/lib/useInactivityLogout.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAccount, useDisconnect } from "wagmi";
+
+/**
+ * Minutes of user inactivity after which a connected wallet is automatically
+ * disconnected. Exported so tests/dev can reference the same constant.
+ */
+export const INACTIVITY_LIMIT_MS = 10 * 60 * 1000;
+
+// Activity within this window of the previous reset is ignored, so a burst of
+// mousemove/scroll events doesn't reschedule the timer hundreds of times.
+const ACTIVITY_THROTTLE_MS = 1000;
+
+const ACTIVITY_EVENTS = ["mousemove", "keydown", "click", "scroll", "touchstart"] as const;
+
+/**
+ * Auto-logs-out (wagmi `disconnect`) after {@link INACTIVITY_LIMIT_MS} of no
+ * user interaction while a wallet is connected. Any pointer/keyboard/touch
+ * activity, or the tab becoming visible again, resets the countdown.
+ *
+ * This only tears down the local wallet connection; it stores no auth state and
+ * a subsequent reconnect re-prompts the wallet. Mount it once, app-wide, inside
+ * the wagmi provider (see `components/Providers.tsx`).
+ */
+export function useInactivityLogout(): void {
+	const { isConnected } = useAccount();
+	const { disconnect } = useDisconnect();
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const lastResetRef = useRef<number>(0);
+
+	useEffect(() => {
+		if (!isConnected) return;
+
+		const reset = (): void => {
+			if (timerRef.current !== null) clearTimeout(timerRef.current);
+			timerRef.current = setTimeout(() => {
+				disconnect();
+			}, INACTIVITY_LIMIT_MS);
+		};
+
+		const onActivity = (): void => {
+			const now = Date.now();
+			if (now - lastResetRef.current < ACTIVITY_THROTTLE_MS) return;
+			lastResetRef.current = now;
+			reset();
+		};
+
+		const onVisibility = (): void => {
+			if (document.visibilityState === "visible") onActivity();
+		};
+
+		for (const event of ACTIVITY_EVENTS) {
+			window.addEventListener(event, onActivity, { passive: true });
+		}
+		document.addEventListener("visibilitychange", onVisibility);
+
+		// Start the countdown immediately on connect.
+		reset();
+
+		return (): void => {
+			for (const event of ACTIVITY_EVENTS) {
+				window.removeEventListener(event, onActivity);
+			}
+			document.removeEventListener("visibilitychange", onVisibility);
+			if (timerRef.current !== null) clearTimeout(timerRef.current);
+		};
+	}, [isConnected, disconnect]);
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,133 @@
+/**
+ * Reusable form-field validators for the TrustLedger frontend.
+ *
+ * Each validator takes the raw input value and returns either an error message
+ * string (explaining *why* the value is invalid and what is accepted) or
+ * `undefined` when the value is valid. Components render the returned string as
+ * red helper text and block submission while any field has an error.
+ *
+ * Example:
+ *   const error = validateEthAddress(input); // "Enter a valid…" | undefined
+ *   <Field error={error}>…</Field>
+ */
+
+import { isAddress, parseEther } from "viem";
+import { resolveDocUrl } from "@/lib/utils";
+
+/** A validator result: an error message, or `undefined` when valid. */
+export type ValidationResult = string | undefined;
+
+/** Requires a non-empty (after trim) value. */
+export function validateRequired(value: string, label = "This field"): ValidationResult {
+	return value.trim() === "" ? `${label} is required.` : undefined;
+}
+
+/** Requires a checksum-valid Ethereum address (0x followed by 40 hex chars). */
+export function validateEthAddress(value: string): ValidationResult {
+	const trimmed = value.trim();
+	if (trimmed === "") return "Enter a wallet address.";
+	if (!isAddress(trimmed)) {
+		return "Enter a valid Ethereum address (0x followed by 40 hex characters).";
+	}
+	return undefined;
+}
+
+/**
+ * Requires a positive ETH amount parseable to wei. `maxEth`, when provided,
+ * caps the value (e.g. the user's balance or a contract limit).
+ */
+export function validateEthAmount(value: string, maxEth?: number): ValidationResult {
+	const trimmed = value.trim();
+	if (trimmed === "") return "Enter an amount in ETH.";
+	const num = Number(trimmed);
+	if (!Number.isFinite(num)) return "Enter a valid number, e.g. 0.05.";
+	if (num <= 0) return "Amount must be greater than 0 ETH.";
+	try {
+		parseEther(trimmed);
+	} catch {
+		return "Enter a valid ETH amount (up to 18 decimal places).";
+	}
+	if (maxEth !== undefined && num > maxEth) {
+		return `Amount exceeds the available ${maxEth.toString()} ETH.`;
+	}
+	return undefined;
+}
+
+/** Requires a finite number within [min, max]; `integer` enforces whole numbers. */
+export function validateNumberInRange(
+	value: string,
+	min: number,
+	max: number,
+	options: { integer?: boolean; unit?: string } = {},
+): ValidationResult {
+	const trimmed = value.trim();
+	const unit = options.unit !== undefined && options.unit !== "" ? ` ${options.unit}` : "";
+	if (trimmed === "") return "Enter a value.";
+	const num = Number(trimmed);
+	if (!Number.isFinite(num)) return "Enter a valid number.";
+	if (options.integer === true && !Number.isInteger(num)) {
+		return "Enter a whole number.";
+	}
+	if (num < min || num > max) {
+		return `Enter a value between ${min.toString()} and ${max.toString()}${unit}.`;
+	}
+	return undefined;
+}
+
+/** Requires a finite number strictly greater than 0. */
+export function validatePositiveNumber(value: string, label = "Value"): ValidationResult {
+	const trimmed = value.trim();
+	if (trimmed === "") return `${label} is required.`;
+	const num = Number(trimmed);
+	if (!Number.isFinite(num)) return "Enter a valid number.";
+	if (num <= 0) return `${label} must be greater than 0.`;
+	return undefined;
+}
+
+/** Requires an integer reputation score in [1, 100]. */
+export function validateScore(value: string): ValidationResult {
+	return validateNumberInRange(value, 1, 100, { integer: true });
+}
+
+/**
+ * Validates an off-chain document URI. Empty is allowed (the field is optional);
+ * a non-empty value must resolve to a real link (ipfs://, ar://, http(s)://, or
+ * a bare IPFS CID). Reuses {@link resolveDocUrl}.
+ */
+export function validateContractUri(value: string): ValidationResult {
+	const trimmed = value.trim();
+	if (trimmed === "") return undefined;
+	if (resolveDocUrl(trimmed) === undefined) {
+		return "Enter an ipfs://, ar://, or https:// link (or a bare IPFS CID).";
+	}
+	return undefined;
+}
+
+/** Like {@link validateContractUri} but the value is mandatory. */
+export function validateRequiredUri(value: string): ValidationResult {
+	const trimmed = value.trim();
+	if (trimmed === "") return "Enter a deliverable URL or IPFS link.";
+	return validateContractUri(trimmed);
+}
+
+// Pragmatic email shape check: a single @, no spaces, a dot in the domain. Full
+// RFC 5322 validation is intentionally avoided - the magic-link send confirms
+// deliverability.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Validates an email address. Empty is allowed unless `required` is set. */
+export function validateEmail(value: string, required = false): ValidationResult {
+	const trimmed = value.trim();
+	if (trimmed === "") return required ? "Enter an email address." : undefined;
+	return EMAIL_RE.test(trimmed) ? undefined : "Enter a valid email, e.g. name@example.com.";
+}
+
+/** Requires a 0x-prefixed hex string (any non-zero length), e.g. a salt. */
+export function validateHex(value: string, label = "Value"): ValidationResult {
+	const trimmed = value.trim();
+	if (trimmed === "") return `${label} is required.`;
+	if (!/^0x[0-9a-fA-F]+$/.test(trimmed)) {
+		return `${label} must be a 0x-prefixed hex string.`;
+	}
+	return undefined;
+}

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -28,6 +28,18 @@ const hasWcProjectId = wcProjectId !== undefined && wcProjectId !== "";
 // NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID for the connect modal to actually pair.
 const projectId = hasWcProjectId ? wcProjectId : "YOUR_PROJECT_ID";
 
+// Relay-based wallets (Tangem, Phantom, MetaMask-mobile via QR, WalletConnect)
+// silently fail to pair without a real project ID - especially on mobile, where
+// there is no injected provider to fall back to. Warn loudly in the browser so
+// the cause isn't a mystery during a mobile Tangem connect attempt.
+if (!hasWcProjectId && typeof window !== "undefined") {
+	console.warn(
+		"[TrustLedger] NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is not set - WalletConnect relay " +
+			"wallets (Tangem, Phantom, mobile MetaMask) will not connect. Get a project ID at " +
+			"https://dashboard.reown.com and set the env var.",
+	);
+}
+
 // Sepolia: testing and development only.
 // Arbitrum / Base / Optimism: production L2s with gas costs proportional to typical contract values.
 const networks: [AppKitNetwork, ...AppKitNetwork[]] = [sepolia, arbitrum, base, optimism];
@@ -35,11 +47,16 @@ const networks: [AppKitNetwork, ...AppKitNetwork[]] = [sepolia, arbitrum, base, 
 // Brand accent shared with the rest of the UI (indigo-500).
 const ACCENT_COLOR = "#6366f1";
 
-// Origin advertised to wallets during pairing. Falls back to the production URL
-// during SSR/build where `window` is undefined.
+// Origin advertised to wallets during pairing. WalletConnect/AppKit requires
+// this to match the actual page origin or mobile wallets (Tangem, etc.) reject
+// the session. On the client we always use the real origin; during SSR/build we
+// fall back to the configured site URL. NEXT_PUBLIC_SITE_URL is preferred;
+// NEXT_PUBLIC_APP_URL is accepted as an alias so a single deployment URL var works.
+const configuredAppUrl = process.env["NEXT_PUBLIC_SITE_URL"] ?? process.env["NEXT_PUBLIC_APP_URL"];
 const appUrl =
-	process.env["NEXT_PUBLIC_SITE_URL"] ??
-	(typeof window !== "undefined" ? window.location.origin : "https://trustledger.vercel.app");
+	typeof window !== "undefined"
+		? window.location.origin
+		: (configuredAppUrl ?? "https://trustledger.vercel.app");
 
 // The wagmi adapter builds the wagmi config AppKit drives. `ssr: true` mirrors
 // the previous getDefaultConfig setup so Next.js server rendering stays correct.


### PR DESCRIPTION
Nine-task hardening pass (single branch per agreed plan).

## Changes
1. **NOTIFICATION_EMAILS** — stopgap JSON map seeded in \`.env\` (local, gitignored).
2. **.gitignore** — ignore repo-root \`/.next\` symlink created by \`vercel-build\`.
3. **Markdown lint** — \`.next/\` already excluded; verified.
4. **Copy wallet address** — \`ConnectButton\` shows address + copy-to-clipboard, 44px tap targets.
5. **Input validation** — new \`lib/validation.ts\` + shared \`components/Field.tsx\`; inline red errors with touched/submit gating across create, reputation, dashboard, juror, arbitration.
6. **Tangem mobile** — warn on placeholder WalletConnect id, reconcile pairing origin (\`NEXT_PUBLIC_SITE_URL\`/\`NEXT_PUBLIC_APP_URL\`), \`docs/WALLETS.md\` test checklist.
7. **React #418** — \`useSyncExternalStore\` mounted gate in \`ConnectButton\` (root cause: wallet-dependent text rendered before hydration).
8. **ReputationRegistry** — deployed + wired in Foundry \`Deploy.s.sol\`; \`deploy.yml\` upserts \`NEXT_PUBLIC_REPUTATION_REGISTRY_ADDRESS\`; \`scripts/sync-frontend-env.ts\` mirrors addresses into \`src/.env.local\` on local deploy.
9. **Wallet persistence** — remembers connector *label* only (no keys/signatures); 10-min inactivity auto-logout in \`Providers\`; "Reconnect with <Wallet>".

## Verification
- \`forge test\` — 97 passed
- \`next build\` — TypeScript + static generation clean
- ESLint (frontend + root), Prettier, \`forge fmt\`, \`forge lint\`, \`solhint\`, \`markdownlint\` — clean
- Local deploy → \`src/.env.local\` sync confirmed (incl. ReputationRegistry)

## Follow-up
- Tangem/mobile NFC pairing requires manual verification per \`docs/WALLETS.md\` (cannot be automated).