### PR TITLE
feat: freelancer proposes, client accepts-by-funding (swap handshake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,15 @@ a hash of the deliverable and its IPFS URI are stored the same way. Neither
 party can alter what was agreed to or what was delivered after the fact. Any
 tampering is immediately detectable by recomputing the hash.
 
-### ECDSA Wallet Binding on Acceptance
+### Accept-to-Fund Handshake
 
-The freelancer does not accept a contract by calling a function alone - they
-must submit an EIP-191 signature over
-`keccak256(contractId, freelancerAddress)`. The contract recovers the signer
-on-chain via `ecrecover` and rejects any mismatch. This prevents a third party
-from accepting a contract on a freelancer's behalf without their private-key
-authorization.
+The freelancer proposes the terms with `proposeContract` (no funds move), and
+the named client accepts by calling `acceptContract` with `msg.value` equal to
+the agreed amount - the funding transaction itself is the client's on-chain
+consent, and the freelancer already proved authorship by sending the proposal.
+The contract enforces that only the named client can accept and that the exact
+amount is locked, so no separate signature is required and funds are never held
+before both parties have committed.
 
 ### Commit-Reveal Voting Prevents Herding
 
@@ -1115,34 +1116,30 @@ off-chain:
 
 #### IPFS Uploads Before On-Chain Calls
 
-Before calling `createContract()`, upload the agreement document to IPFS and
+Before calling `proposeContract()`, upload the agreement document to IPFS and
 pass the resulting CID as `contractURI`. Before calling `submitProofOfWork()`,
 upload the deliverable and pass the CID as `proofOfWorkURI`. The Solidity
 contract stores the CID and a `keccak256` hash of the file - the backend must
 hash the file before upload and pass both values.
 
-#### Magic-Link Freelancer Onboarding
+#### Magic-Link Client Onboarding
 
-The client submits the contract via the website and a signed magic link is
-emailed to the freelancer. The backend generates a single-use JWT containing the
-`contractId`, emails it to the freelancer's address, and the frontend uses the
-link to pre-fill the `acceptContract()` call. The on-chain acceptance requires a
-pre-computed ECDSA signature:
+The freelancer proposes the contract via the website and a signed magic link is
+emailed to the client. The backend generates a single-use token containing the
+`contractId`, emails it to the client's address, and the frontend uses the link
+to pre-fill the `acceptContract()` call. Acceptance funds the escrow in one
+transaction - no signature is needed, just the ETH value (or a prior ERC-20
+approval):
 
 ```ts
-const inner = ethers.solidityPackedKeccak256(
-    ["uint256", "address"],
-    [contractId, freelancerAddress],
-);
-const sig = ethers.Signature.from(
-    await wallet.signMessage(ethers.getBytes(inner)),
-);
-// Call: trustLedger.acceptContract(contractId, sig.v, sig.r, sig.s)
+// Call: trustLedger.acceptContract(contractId, { value: amount })
+// ERC-20 escrow: token.approve(trustLedger, amount) first, then
+//                trustLedger.acceptContract(contractId)
 ```
 
 #### Deadline Notifications
 
-Subscribe to `ContractCreated` and `ContractAccepted` events. For each active
+Subscribe to `ContractProposed` and `ContractAccepted` events. For each active
 contract, compare `projectDeadline` (stored in the `EscrowContract` struct via
 `getContract(id)`) against the current block time. Send deadline warnings
 starting 5 days out in 24-hour increments.
@@ -1260,7 +1257,7 @@ TrustLedger/
 │   │   ├── arbitration/[id]/page.tsx             # Per-dispute commit/reveal voting UI
 │   │   ├── create/page.tsx                       # Create escrow contract form
 │   │   ├── dashboard/page.tsx                    # User's contract dashboard
-│   │   ├── freelancer/accept/page.tsx            # Magic-link freelancer accept landing page
+│   │   ├── client/accept/page.tsx                # Magic-link client review/accept landing page
 │   │   ├── juror/page.tsx                        # Juror portal - stake, vote, view disputes
 │   │   ├── reputation/page.tsx                   # Reputation lookup and post-contract rating UI
 │   │   ├── layout.tsx                            # Root layout with Providers + Navbar

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,7 +62,7 @@ risk.
 | Logic bugs            | Incorrect payout math, fee calculation errors, state machine violations             |
 | Access control        | Functions callable by unauthorized addresses                                        |
 | Reentrancy            | ETH or token transfers before state updates                                         |
-| Signature issues      | Replay attacks, malformed ECDSA validation in `acceptContract()`                    |
+| Escrow funding        | Value mismatch, mis-funding, or unauthorized acceptance in `acceptContract()`       |
 | Arbitration integrity | Vote manipulation, juror slashing errors, appeal window bypass                      |
 
 ### Out of Scope

--- a/contracts/src/TrustLedger.sol
+++ b/contracts/src/TrustLedger.sol
@@ -14,16 +14,16 @@ import {IReputationRegistry} from "./interfaces/IReputationRegistry.sol";
 
 // TrustLedger is the core escrow contract. It holds ETH (or ERC-20 tokens) between
 // a client and a freelancer and enforces a lifecycle of states that protect both parties:
-//   Client deposits → Freelancer accepts (with wallet signature) → Freelancer submits work →
+//   Freelancer proposes → Client accepts & funds escrow → Freelancer submits work →
 //   Client approves (or disputes) → Funds released (or arbitrated)
 //
 // New in Part 1:
 //   - Proportional fee split: fee burden shared by completion percentage, not flat deduction.
 //   - Bidirectional reputation: both parties rate each other post-completion via ReputationRegistry.
-//   - Contract amendment: client can cancel a PENDING contract and redeploy with new terms.
-//   - Wallet binding: acceptContract requires an ECDSA signature proving key ownership.
+//   - Contract amendment: freelancer can cancel a PENDING proposal and re-propose with new terms.
+//   - Accept-to-fund: the freelancer proposes unfunded terms; the client's funding tx is its consent.
 //   - Stablecoin support: optional ERC-20 token escrow alongside native ETH.
-//   - Chainlink price feed: ETH/USD rate locked at creation for informational USD tracking.
+//   - Chainlink price feed: ETH/USD rate locked at acceptance for informational USD tracking.
 //
 // `is ReentrancyGuard` mixes in OpenZeppelin's nonReentrant modifier so that
 // functions sending ETH or tokens cannot be called recursively by a malicious contract.
@@ -40,8 +40,8 @@ contract TrustLedger is ReentrancyGuard, Pausable {
     // it as a uint8 (0, 1, 2 …). Using an enum instead of raw numbers makes the
     // code self-documenting and prevents typos.
     enum Status {
-        PENDING, // 0 - Contract created; freelancer hasn't responded yet
-        ACTIVE, // 1 - Freelancer accepted; project deadline is counting down
+        PENDING, // 0 - Freelancer proposed terms; client hasn't funded/responded yet
+        ACTIVE, // 1 - Client accepted and funded escrow; project deadline is counting down
         SUBMITTED, // 2 - Freelancer submitted proof-of-work; acceptance window running
         APPROVED, // 3 - Client approved OR acceptance window elapsed (auto-release)
         DISPUTED, // 4 - Client opened a dispute; awaiting arbitration
@@ -174,18 +174,18 @@ contract TrustLedger is ReentrancyGuard, Pausable {
     // ─── Events
     // ──────────────────────────────────────────────────────────────
 
-    /// @notice Emitted when a new escrow contract is created.
+    /// @notice Emitted when a freelancer proposes a new (unfunded) escrow contract.
     /// @param id         Contract identifier.
-    /// @param client     Address that deposited funds.
-    /// @param freelancer Address hired to complete the work.
-    /// @param amount     Funds locked in escrow (ETH wei or token units).
-    event ContractCreated(uint256 indexed id, address indexed client, address indexed freelancer, uint256 amount);
+    /// @param client     Address expected to review and fund the escrow on acceptance.
+    /// @param freelancer Address that proposed the terms and will complete the work.
+    /// @param amount     Funds the client will lock in escrow on acceptance (ETH wei or token units).
+    event ContractProposed(uint256 indexed id, address indexed client, address indexed freelancer, uint256 amount);
 
-    /// @notice Emitted when the freelancer accepts the contract.
+    /// @notice Emitted when the client accepts the proposal and funds the escrow.
     /// @param id Contract identifier.
     event ContractAccepted(uint256 indexed id);
 
-    /// @notice Emitted when the freelancer rejects the contract.
+    /// @notice Emitted when the client rejects the freelancer's proposal.
     /// @param id Contract identifier.
     event ContractRejected(uint256 indexed id);
 
@@ -275,10 +275,10 @@ contract TrustLedger is ReentrancyGuard, Pausable {
     /// @notice No funds were sent with the transaction.
     error InsufficientFunds();
 
-    /// @notice The freelancer address cannot be the zero address.
+    /// @notice A required address (client or freelancer) cannot be the zero address.
     error ZeroAddress();
 
-    /// @notice The client cannot hire themselves.
+    /// @notice The freelancer cannot propose a contract to themselves as the client.
     error SelfContract();
 
     /// @notice completionPct is greater than 100.
@@ -292,9 +292,6 @@ contract TrustLedger is ReentrancyGuard, Pausable {
 
     /// @notice Mismatch between token address and funding params (ETH vs token).
     error InvalidTokenParams();
-
-    /// @notice ECDSA signature does not recover to the expected freelancer address.
-    error InvalidSignature();
 
     /// @notice Rating score must be between 1 and 100 inclusive.
     error RatingOutOfRange();
@@ -376,7 +373,7 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         pauser = pauser_;
     }
 
-    /// @notice Pause createContract, blocking new escrows from being opened.
+    /// @notice Pause proposeContract, blocking new escrows from being proposed.
     ///         All in-flight lifecycle functions (accept, submit, approve, dispute, claim) remain active
     ///         so that funds already in escrow can always exit.
     function pause() external {
@@ -386,7 +383,7 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         _pause();
     }
 
-    /// @notice Unpause createContract, re-enabling new escrow creation.
+    /// @notice Unpause proposeContract, re-enabling new escrow proposals.
     function unpause() external {
         if (msg.sender != pauser) {
             revert NotPauser();
@@ -394,14 +391,14 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         _unpause();
     }
 
-    // ─── Client: create
+    // ─── Freelancer: propose
     // ───────────────────────────────────────────────────────
 
-    /// @notice Create an escrow contract and lock funds. Emits {ContractCreated}.
-    ///         For ETH escrow: set token = address(0), tokenAmount = 0, and send ETH as msg.value.
-    ///         For ERC-20 escrow: set token = token address, tokenAmount = amount, msg.value = 0.
-    ///         The client must have pre-approved this contract for tokenAmount before calling.
-    /// @param freelancer        Address of the hired freelancer.
+    /// @notice Propose an escrow contract. The caller is the freelancer; no funds move
+    ///         until the named client accepts via {acceptContract}. Emits {ContractProposed}.
+    ///         For ETH escrow:    set token = address(0) and amount = the wei the client will lock.
+    ///         For ERC-20 escrow: set token = token address and amount = the token units to lock.
+    /// @param client            Address expected to review and fund the escrow.
     /// @param contractHash      keccak256 of the off-chain contract document.
     /// @param contractURI       IPFS URI pointing to the contract document.
     /// @param estimatedDuration How long the project should take, in seconds.
@@ -411,10 +408,10 @@ contract TrustLedger is ReentrancyGuard, Pausable {
     /// @param holdBackBps       Warranty retention as basis points (0 = none; or 500-1500).
     /// @param warrantyPeriod    How long warranty hold-back is locked after approval, in seconds.
     /// @param token             ERC-20 token address; use address(0) for native ETH.
-    /// @param tokenAmount       Token units to escrow; must be 0 for ETH escrows.
-    /// @return id               The ID of the newly created escrow contract.
-    function createContract(
-        address freelancer,
+    /// @param amount            Escrow amount the client will lock on acceptance (wei or token units).
+    /// @return id               The ID of the newly proposed escrow contract.
+    function proposeContract(
+        address client,
         bytes32 contractHash,
         string calldata contractURI,
         uint256 estimatedDuration,
@@ -424,10 +421,9 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         uint16 holdBackBps,
         uint64 warrantyPeriod,
         address token,
-        uint256 tokenAmount
+        uint256 amount
     )
         external
-        payable
         whenNotPaused
         returns (uint256 id)
     {
@@ -437,58 +433,52 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         if (bytes(contractURI).length == 0) {
             revert EmptyURI();
         }
-        _validateCreateParams({
-            freelancer: freelancer,
+        _validateProposeParams({
+            client: client,
             bufferFactor: bufferFactor,
             acceptanceWindow: acceptanceWindow,
             arbitrationFeeBps: arbitrationFeeBps,
             holdBackBps: holdBackBps,
             warrantyPeriod: warrantyPeriod,
-            token: token,
-            tokenAmount: tokenAmount
+            amount: amount
         });
 
         id = nextId;
         ++nextId;
 
-        uint256 escrowAmount = token == address(0) ? msg.value : tokenAmount;
-        uint256 deadline = block.timestamp + (estimatedDuration * bufferFactor) / 1000;
-        uint256 usdValue = token == address(0) ? _queryUsdValue(msg.value) : 0;
+        // No funds are held while PENDING, so the project deadline cannot start counting
+        // from proposal time (an arbitrary client delay would eat the freelancer's working
+        // window). Store the buffered duration (seconds) in projectDeadline now; acceptContract
+        // converts it to an absolute timestamp = block.timestamp + duration when the client funds.
+        uint256 bufferedDuration = (estimatedDuration * bufferFactor) / 1000;
 
         _storeEscrow({
             id: id,
-            freelancer: freelancer,
+            client: client,
             contractHash: contractHash,
             contractURI: contractURI,
-            deadline: deadline,
+            deadline: bufferedDuration,
             acceptanceWindow: acceptanceWindow,
             arbitrationFeeBps: arbitrationFeeBps,
             holdBackBps: holdBackBps,
             warrantyPeriod: warrantyPeriod,
             token: token,
-            escrowAmount: escrowAmount,
-            usdValue: usdValue
+            escrowAmount: amount,
+            usdValue: 0 // computed at acceptance, when the ETH value is actually locked
         });
 
-        if (token != address(0)) {
-            bool ok = IERC20(token).transferFrom(msg.sender, address(this), tokenAmount);
-            if (!ok) {
-                revert TokenTransferFailed();
-            }
-        }
-
-        emit ContractCreated(id, msg.sender, freelancer, escrowAmount);
+        emit ContractProposed(id, client, msg.sender, amount);
     }
 
-    // ─── Client: cancel pending
+    // ─── Freelancer: withdraw proposal
     // ───────────────────────────────────────────────
 
-    /// @notice Client cancels a PENDING contract before the freelancer responds.
-    ///         Returns all escrowed funds to the client. Emits {ContractCancelled}.
+    /// @notice Freelancer withdraws their own PENDING proposal before the client funds it.
+    ///         No funds are held while PENDING, so nothing is transferred. Emits {ContractCancelled}.
     /// @param id The escrow contract ID.
-    function cancelPending(uint256 id) external nonReentrant {
+    function cancelProposal(uint256 id) external {
         EscrowContract storage c = _contracts[id];
-        if (msg.sender != c.client) {
+        if (msg.sender != c.freelancer) {
             revert Unauthorized();
         }
         if (c.status != Status.PENDING) {
@@ -496,39 +486,33 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         }
 
         c.status = Status.CANCELLED;
-
-        // Zero out amount before sending - checks-effects-interactions pattern.
-        uint256 amount = c.amount;
-        c.amount = 0;
-
-        _sendFunds(c, c.client, amount);
         emit ContractCancelled(id);
     }
 
-    // ─── Client: amendment linking
+    // ─── Freelancer: amendment linking
     // ────────────────────────────────────────────
 
-    /// @notice Links a PENDING replacement contract to its CANCELLED predecessor,
+    /// @notice Links a PENDING replacement proposal to its CANCELLED predecessor,
     ///         establishing an on-chain amendment version history. Emits {ContractAmended}.
     ///
     ///         Amendment flow:
-    ///           1. Client calls cancelPending(oldId)  → oldId becomes CANCELLED.
-    ///           2. Client calls createContract(...)   → newId is PENDING.
-    ///           3. Client calls linkAmendment(newId, oldId) → on-chain link recorded.
+    ///           1. Freelancer calls cancelProposal(oldId)  → oldId becomes CANCELLED.
+    ///           2. Freelancer calls proposeContract(...)   → newId is PENDING.
+    ///           3. Freelancer calls linkAmendment(newId, oldId) → on-chain link recorded.
     ///
     ///         Constraints:
-    ///           - Caller must be the client on both contracts.
+    ///           - Caller must be the freelancer on both contracts.
     ///           - oldId must be CANCELLED; newId must be PENDING.
     ///           - newId must not already have a predecessor (each contract links to at most one).
     /// @param newId      The replacement contract ID.
-    /// @param previousId The cancelled contract ID being superseded.
+    /// @param previousId the cancelled contract ID being superseded.
     function linkAmendment(uint256 newId, uint256 previousId) external {
         EscrowContract storage oldC = _contracts[previousId];
         EscrowContract storage newC = _contracts[newId];
-        if (msg.sender != oldC.client) {
+        if (msg.sender != oldC.freelancer) {
             revert InvalidPreviousContract();
         }
-        if (msg.sender != newC.client) {
+        if (msg.sender != newC.freelancer) {
             revert Unauthorized();
         }
         if (oldC.status != Status.CANCELLED) {
@@ -633,60 +617,55 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         emit ContractCancelled(id);
     }
 
-    // ─── Freelancer: accept / reject
+    // ─── Client: accept / reject
     // ──────────────────────────────────────────
 
-    /// @notice Freelancer accepts the contract by providing a wallet signature. Emits {ContractAccepted}.
-    ///         The signature must be: eth_sign(keccak256(abi.encodePacked(id, freelancerAddress))).
-    ///         This proves the freelancer controls the private key for the address on the contract.
+    /// @notice Client accepts the freelancer's proposal and funds the escrow. Emits {ContractAccepted}.
+    ///         The funding transaction itself is the client's consent — no separate signature is needed,
+    ///         and the freelancer already proved authorship by sending {proposeContract}.
+    ///         For ETH escrow:    send msg.value == the proposed amount.
+    ///         For ERC-20 escrow: send no ETH; the client must have pre-approved this contract for the
+    ///                            proposed amount, which is pulled via transferFrom.
     /// @param id The escrow contract ID.
-    /// @param v  Signature recovery byte (27 or 28).
-    /// @param r  Signature r component.
-    /// @param s  Signature s component.
-    function acceptContract(uint256 id, uint8 v, bytes32 r, bytes32 s) external {
+    function acceptContract(uint256 id) external payable nonReentrant {
         EscrowContract storage c = _contracts[id];
-        if (msg.sender != c.freelancer) {
+        if (msg.sender != c.client) {
             revert Unauthorized();
         }
         if (c.status != Status.PENDING) {
             revert InvalidStatus(c.status);
         }
-        if (block.timestamp > c.projectDeadline) {
-            revert DeadlineElapsed();
+
+        // Fund the escrow. The proposed amount lives in c.amount; the client must lock exactly that.
+        if (c.token == address(0)) {
+            if (msg.value != c.amount) {
+                revert InsufficientFunds();
+            }
+        } else {
+            if (msg.value != 0) {
+                revert InvalidTokenParams(); // no ETH should accompany a token escrow
+            }
+            bool ok = IERC20(c.token).transferFrom(msg.sender, address(this), c.amount);
+            if (!ok) {
+                revert TokenTransferFailed();
+            }
         }
 
-        // Reconstruct the message the freelancer should have signed.
-        // innerHash binds the signature to this specific contract ID and freelancer address,
-        // preventing replay across different contracts or different wallets.
-        // Rationale: keep the high-level keccak256 over an inline-assembly variant. This is
-        // security-critical EIP-191 signature verification; Solidity-level hashing is far more
-        // auditable and the marginal gas saving is not worth the assembly risk here.
-        // forge-lint: disable-next-line(asm-keccak256)
-        bytes32 innerHash = keccak256(abi.encodePacked(id, c.freelancer));
-
-        // EIP-191 prefix makes this compatible with eth_sign / personal_sign in wallets.
-        // The "\x19Ethereum Signed Message:\n32" prefix prevents signed data from being
-        // misused as a raw transaction.
-        // Rationale: see above — auditability of signature hashing outweighs the gas micro-opt.
-        // forge-lint: disable-next-line(asm-keccak256)
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", innerHash));
-
-        // ecrecover returns the address of the private key holder who signed ethSignedHash.
-        // If the sig is invalid, ecrecover returns address(0).
-        address signer = ecrecover(ethSignedHash, v, r, s);
-        if (signer != c.freelancer) {
-            revert InvalidSignature();
-        }
-
+        // The project deadline counts from acceptance. proposeContract stashed the buffered duration
+        // (seconds) in projectDeadline; convert it to an absolute timestamp now that work can begin.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        c.projectDeadline = uint64(block.timestamp + uint256(c.projectDeadline));
+        c.usdValueAtCreation = c.token == address(0) ? _queryUsdValue(msg.value) : 0;
         c.status = Status.ACTIVE;
         emit ContractAccepted(id);
     }
 
-    /// @notice Freelancer rejects the contract and returns funds to the client. Emits {ContractRejected}.
+    /// @notice Client rejects the freelancer's proposal. No funds are held while PENDING, so nothing
+    ///         is transferred. Emits {ContractRejected}.
     /// @param id The escrow contract ID.
-    function rejectContract(uint256 id) external nonReentrant {
+    function rejectContract(uint256 id) external {
         EscrowContract storage c = _contracts[id];
-        if (msg.sender != c.freelancer) {
+        if (msg.sender != c.client) {
             revert Unauthorized();
         }
         if (c.status != Status.PENDING) {
@@ -694,10 +673,6 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         }
 
         c.status = Status.CANCELLED;
-        uint256 amount = c.amount;
-        c.amount = 0;
-
-        _sendFunds(c, c.client, amount);
         emit ContractRejected(id);
     }
 
@@ -924,25 +899,27 @@ contract TrustLedger is ReentrancyGuard, Pausable {
     // ─── Internal
     // ─────────────────────────────────────────────────────────────
 
-    // Validation helper extracted from createContract to keep the function under the line limit.
-    function _validateCreateParams(
-        address freelancer,
+    // Validation helper extracted from proposeContract to keep the function under the line limit.
+    function _validateProposeParams(
+        address client,
         uint256 bufferFactor,
         uint256 acceptanceWindow,
         uint16 arbitrationFeeBps,
         uint16 holdBackBps,
         uint64 warrantyPeriod,
-        address token,
-        uint256 tokenAmount
+        uint256 amount
     )
         internal
         view
     {
-        if (freelancer == address(0)) {
+        if (client == address(0)) {
             revert ZeroAddress();
         }
-        if (freelancer == msg.sender) {
+        if (client == msg.sender) {
             revert SelfContract();
+        }
+        if (amount == 0) {
+            revert InsufficientFunds(); // a proposal must name a non-zero escrow amount
         }
         if (bufferFactor < MIN_BUFFER_FACTOR) {
             revert InvalidBufferFactor();
@@ -963,28 +940,12 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         if (holdBackBps == 0 && warrantyPeriod != 0) {
             revert InvalidWarrantyPeriod();
         }
-        // Exactly one of ETH or ERC-20 must be funded; the other must be zero.
-        if (token == address(0)) {
-            if (msg.value == 0) {
-                revert InsufficientFunds(); // ETH escrow needs ETH
-            }
-            if (tokenAmount != 0) {
-                revert InvalidTokenParams(); // must not specify token amount for ETH escrow
-            }
-        } else {
-            if (msg.value != 0) {
-                revert InvalidTokenParams(); // must not send ETH for token escrow
-            }
-            if (tokenAmount == 0) {
-                revert InsufficientFunds(); // token escrow needs tokens
-            }
-        }
     }
 
-    // Struct-initialisation helper extracted from createContract to keep the function under the line limit.
+    // Struct-initialisation helper extracted from proposeContract to keep the function under the line limit.
     function _storeEscrow(
         uint256 id,
-        address freelancer,
+        address client,
         bytes32 contractHash,
         string calldata contractURI,
         uint256 deadline,
@@ -1003,8 +964,8 @@ contract TrustLedger is ReentrancyGuard, Pausable {
         // forge-lint: disable-next-line(unsafe-typecast)
         uint64 aw = uint64(acceptanceWindow);
         _contracts[id] = EscrowContract({
-            client: msg.sender,
-            freelancer: freelancer,
+            client: client,
+            freelancer: msg.sender,
             contractHash: contractHash,
             contractURI: contractURI,
             projectDeadline: dl,

--- a/contracts/src/mocks/MockPriceFeed.sol
+++ b/contracts/src/mocks/MockPriceFeed.sol
@@ -14,7 +14,7 @@ pragma solidity ^0.8.24;
 /// @author Kevin Le, Kellen Snider
 /// @notice Test-only Chainlink AggregatorV3Interface substitute.
 ///         Returns a configurable int256 price from latestRoundData() so tests
-///         can verify ETH/USD locking behaviour in TrustLedger.createContract().
+///         can verify ETH/USD locking behaviour in TrustLedger.acceptContract().
 contract MockPriceFeed {
     // ─── State
     // ────────────────────────────────────────────────────────────────

--- a/contracts/test/fork/FullLifecycleFork.t.sol
+++ b/contracts/test/fork/FullLifecycleFork.t.sol
@@ -22,7 +22,7 @@ pragma solidity ^0.8.24;
 //
 //   npm run foundry:test:fork
 
-import {Test, Vm} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {Arbitration} from "./../../src/Arbitration.sol";
 import {JurorRegistry} from "./../../src/JurorRegistry.sol";
 import {TrustLedger} from "./../../src/TrustLedger.sol";
@@ -46,11 +46,7 @@ contract FullLifecycleFork is Test {
     JurorRegistry public jurorRegistry;
 
     address public client = makeAddr("client");
-
-    // The freelancer wallet holds a private key so the ECDSA acceptance
-    // signature can be reproduced in tests (mirrors the unit test pattern).
-    Vm.Wallet internal _freelancerWallet;
-    address public freelancer;
+    address public freelancer = makeAddr("freelancer");
 
     // ── setUp
     // ─────────────────────────────────────────────────────────────────
@@ -70,13 +66,10 @@ contract FullLifecycleFork is Test {
             vm.createSelectFork(rpcUrl, blockNumber);
         }
 
-        _freelancerWallet = vm.createWallet("freelancer");
-        freelancer = _freelancerWallet.addr;
-
         vm.deal(client, 100 ether);
         vm.deal(freelancer, 10 ether);
-        // The deterministic address from vm.createWallet may be a deployed contract
-        // on the live fork. Clear its bytecode so ETH transfers behave like a plain EOA.
+        // The deterministic makeAddr may collide with a deployed contract on the live
+        // fork. Clear its bytecode so ETH transfers behave like a plain EOA.
         vm.etch(freelancer, "");
 
         // ── Replicate Deploy.s.sol nonce-prediction logic
@@ -102,41 +95,29 @@ contract FullLifecycleFork is Test {
         vm.deal(address(arbitration), 0);
     }
 
-    // ─── Signing helper
-    // ───────────────────────────────────────────────────────
-    function _signAccept(uint256 id) internal view returns (uint8 v, bytes32 r, bytes32 s) {
-        bytes32 innerHash = keccak256(abi.encodePacked(id, freelancer));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", innerHash));
-        (v, r, s) = vm.sign(_freelancerWallet.privateKey, ethSignedHash);
-    }
-
     // ─── Lifecycle helpers
     // ────────────────────────────────────────────────────
     function _createContract() internal returns (uint256 id) {
-        vm.prank(client);
-        id = trustLedger.createContract{value: AMOUNT}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        id = trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
             bufferFactor: BUFFER_FACTOR,
             acceptanceWindow: ACCEPTANCE_WINDOW,
             arbitrationFeeBps: ARB_FEE_BPS,
-            holdBackBps: 0,
-            warrantyPeriod: // no hold-back
-            0,
-            token: // no warranty
-            address(0),
-            tokenAmount: // native ETH escrow
-            0
+            holdBackBps: 0, // no hold-back
+            warrantyPeriod: 0, // no warranty
+            token: address(0), // native ETH escrow
+            amount: AMOUNT
         });
     }
 
     function _createAndAccept() internal returns (uint256 id) {
         id = _createContract();
-        (uint8 v, bytes32 r, bytes32 s) = _signAccept(id);
-        vm.prank(freelancer);
-        trustLedger.acceptContract(id, v, r, s);
+        vm.prank(client);
+        trustLedger.acceptContract{value: AMOUNT}(id);
     }
 
     function _createAcceptAndSubmit() internal returns (uint256 id) {
@@ -211,18 +192,18 @@ contract FullLifecycleFork is Test {
         assertEq(freelancer.balance, freelancerBefore + remaining, "freelancer should receive full remaining");
     }
 
-    /// @notice Cancellation refunds the client on a fork, verifying no state
-    /// from the forked chain interferes with the escrow accounting.
-    function test_Fork_CancelPending_RefundsClient() public {
+    /// @notice Freelancer withdrawing a proposal on a fork moves it to CANCELLED
+    /// without touching balances (no funds are held until the client accepts).
+    function test_Fork_CancelProposal_ByFreelancer() public {
         uint256 id = _createContract();
 
         uint256 clientBefore = client.balance;
 
-        vm.prank(client);
-        trustLedger.cancelPending(id);
+        vm.prank(freelancer);
+        trustLedger.cancelProposal(id);
 
         TrustLedger.EscrowContract memory c = trustLedger.getContract(id);
         assertEq(uint8(c.status), uint8(TrustLedger.Status.CANCELLED), "status should be CANCELLED");
-        assertEq(client.balance, clientBefore + AMOUNT, "client should be fully refunded");
+        assertEq(client.balance, clientBefore, "client balance should be unchanged");
     }
 }

--- a/contracts/test/fuzz/PayoutFuzz.t.sol
+++ b/contracts/test/fuzz/PayoutFuzz.t.sol
@@ -15,7 +15,7 @@ pragma solidity ^0.8.24;
 //   - Deadlines are always in the future.
 //   - Hold-back amounts stay within their declared percentage bounds.
 
-import {Test, Vm} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {Arbitration} from "./../../src/Arbitration.sol";
 import {JurorRegistry} from "./../../src/JurorRegistry.sol";
 import {TrustLedger} from "./../../src/TrustLedger.sol";
@@ -29,16 +29,9 @@ contract PayoutFuzz is Test {
     JurorRegistry public jurorRegistry;
 
     address public client = makeAddr("client");
-
-    // The freelancer wallet is created via vm.createWallet to obtain the private key
-    // needed for signing the ECDSA acceptance in acceptContract().
-    Vm.Wallet internal _freelancerWallet;
-    address public freelancer;
+    address public freelancer = makeAddr("freelancer");
 
     function setUp() public {
-        _freelancerWallet = vm.createWallet("freelancer");
-        freelancer = _freelancerWallet.addr;
-
         // Give the client enough ETH for even the largest fuzz inputs.
         // type(uint128).max ≈ 3.4 × 10^38 wei. Uint128 is used as the fuzz input
         // type because uint256 amounts could overflow intermediate calculations.
@@ -53,17 +46,11 @@ contract PayoutFuzz is Test {
         arbitration = new Arbitration(address(trustLedger), address(jurorRegistry));
     }
 
-    function _signAccept(uint256 id) internal view returns (uint8 v, bytes32 r, bytes32 s) {
-        bytes32 innerHash = keccak256(abi.encodePacked(id, freelancer));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", innerHash));
-        (v, r, s) = vm.sign(_freelancerWallet.privateKey, ethSignedHash);
-    }
-
-    /// Creates a contract, accepts it, and submits proof of work with no hold-back.
+    /// Proposes a contract, has the client accept and fund it, and submits proof of work with no hold-back.
     function _createSubmitted(uint128 amount, uint16 arbitrationFeeBps) internal returns (uint256 id) {
-        vm.prank(client);
-        id = trustLedger.createContract{value: amount}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        id = trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: "ipfs://contract",
             estimatedDuration: 30 days,
@@ -73,11 +60,10 @@ contract PayoutFuzz is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: amount
         });
-        (uint8 v, bytes32 r, bytes32 s) = _signAccept(id);
-        vm.prank(freelancer);
-        trustLedger.acceptContract(id, v, r, s);
+        vm.prank(client);
+        trustLedger.acceptContract{value: amount}(id);
         vm.prank(freelancer);
         trustLedger.submitProofOfWork(id, POW_HASH, "ipfs://pow");
     }
@@ -172,9 +158,9 @@ contract PayoutFuzz is Test {
 
         uint256 ts = vm.getBlockTimestamp();
 
-        vm.prank(client);
-        uint256 id = trustLedger.createContract{value: 1 ether}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        uint256 id = trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: "ipfs://contract",
             estimatedDuration: estimatedDuration,
@@ -184,8 +170,13 @@ contract PayoutFuzz is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: 1 ether
         });
+
+        // The deadline only becomes absolute once the client accepts (same block here, so ts is
+        // unchanged). Before acceptance projectDeadline holds the relative buffered duration.
+        vm.prank(client);
+        trustLedger.acceptContract{value: 1 ether}(id);
 
         TrustLedger.EscrowContract memory c = trustLedger.getContract(id);
 
@@ -212,9 +203,9 @@ contract PayoutFuzz is Test {
         // cause many rejected runs and slow down the fuzzer).
         uint16 holdBackBps = uint16(500 + (uint256(holdBackBpsRaw) % 1001));
 
-        vm.prank(client);
-        uint256 id = trustLedger.createContract{value: amount}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        uint256 id = trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: "ipfs://contract",
             estimatedDuration: 30 days,
@@ -224,12 +215,11 @@ contract PayoutFuzz is Test {
             holdBackBps: holdBackBps,
             warrantyPeriod: 7 days,
             token: address(0),
-            tokenAmount: 0
+            amount: amount
         });
 
-        (uint8 v, bytes32 r, bytes32 s) = _signAccept(id);
-        vm.prank(freelancer);
-        trustLedger.acceptContract(id, v, r, s);
+        vm.prank(client);
+        trustLedger.acceptContract{value: amount}(id);
         vm.prank(freelancer);
         trustLedger.submitProofOfWork(id, POW_HASH, "ipfs://pow");
         vm.prank(client);

--- a/contracts/test/unit/TrustLedgerTest.t.sol
+++ b/contracts/test/unit/TrustLedgerTest.t.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.24;
 // solhint-disable gas-small-strings
 // solhint-disable ordering
 
-import {Test, Vm} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {Arbitration} from "./../../src/Arbitration.sol";
 import {JurorRegistry} from "./../../src/JurorRegistry.sol";
 import {ReputationRegistry} from "./../../src/ReputationRegistry.sol";
@@ -35,20 +35,13 @@ contract TrustLedgerTest is Test {
     JurorRegistry public jurorRegistry;
 
     address public client = makeAddr("client");
-
-    // The freelancer needs a private key (for ECDSA signing in acceptContract).
-    // vm.createWallet gives us both the address and the key.
-    Vm.Wallet internal _freelancerWallet;
-    address public freelancer;
+    address public freelancer = makeAddr("freelancer");
 
     address public stranger = makeAddr("stranger");
 
     // ── setUp
     // ─────────────────────────────────────────────────────────────────
     function setUp() public {
-        _freelancerWallet = vm.createWallet("freelancer");
-        freelancer = _freelancerWallet.addr;
-
         vm.deal(client, 100 ether);
         vm.deal(freelancer, 10 ether);
         vm.deal(stranger, 10 ether);
@@ -64,24 +57,15 @@ contract TrustLedgerTest is Test {
         assertEq(address(arbitration), arbitrationAddr, "address mismatch");
     }
 
-    // ─── Signing helper
-    // ───────────────────────────────────────────────────────
-    // Computes the EIP-191 signed hash and signs it with the freelancer's private key.
-    // This mirrors the on-chain ecrecover call inside acceptContract().
-    function _signAccept(uint256 id) internal view returns (uint8 v, bytes32 r, bytes32 s) {
-        bytes32 innerHash = keccak256(abi.encodePacked(id, freelancer));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", innerHash));
-        (v, r, s) = vm.sign(_freelancerWallet.privateKey, ethSignedHash);
-    }
-
     // ─── Lifecycle helpers
     // ────────────────────────────────────────────────────
 
-    // Creates a contract with configurable hold-back and warranty.
+    // Freelancer proposes a contract with configurable hold-back and warranty.
+    // No funds move yet; the contract sits PENDING until the client accepts.
     function _createContract(uint16 holdBackBps, uint64 warrantyPeriod) internal returns (uint256 id) {
-        vm.prank(client);
-        id = trustLedger.createContract{value: AMOUNT}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        id = trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -91,22 +75,20 @@ contract TrustLedgerTest is Test {
             holdBackBps: holdBackBps,
             warrantyPeriod: warrantyPeriod,
             token: address(0),
-            tokenAmount: // ETH escrow
-            0 // no token amount
+            amount: AMOUNT
         });
     }
 
-    // Creates a simple ETH contract with no hold-back.
+    // Proposes a simple ETH contract with no hold-back.
     function _createSimpleContract() internal returns (uint256 id) {
         return _createContract(0, 0);
     }
 
-    // Creates and has the freelancer accept (signs + calls acceptContract).
+    // Proposes and has the client accept by funding the escrow.
     function _createAndAccept() internal returns (uint256 id) {
         id = _createSimpleContract();
-        (uint8 v, bytes32 r, bytes32 s) = _signAccept(id);
-        vm.prank(freelancer);
-        trustLedger.acceptContract(id, v, r, s);
+        vm.prank(client);
+        trustLedger.acceptContract{value: AMOUNT}(id);
     }
 
     // Creates, accepts, and submits proof of work.
@@ -139,9 +121,8 @@ contract TrustLedgerTest is Test {
     function test_HappyPath_WithHoldBack() public {
         uint256 id = _createContract(HOLD_BACK_BPS, WARRANTY_PERIOD);
 
-        (uint8 v, bytes32 r, bytes32 s) = _signAccept(id);
-        vm.prank(freelancer);
-        trustLedger.acceptContract(id, v, r, s);
+        vm.prank(client);
+        trustLedger.acceptContract{value: AMOUNT}(id);
 
         vm.prank(freelancer);
         trustLedger.submitProofOfWork(id, POW_HASH, POW_URI);
@@ -170,46 +151,48 @@ contract TrustLedgerTest is Test {
         assertEq(freelancer.balance, freelancerBefore2 + holdBack, "warranty claim mismatch");
     }
 
-    // ─── Cancel Pending
+    // ─── Cancel Proposal
     // ───────────────────────────────────────────────────────
 
-    function test_CancelPending_RefundsClient() public {
+    function test_CancelProposal_ByFreelancer() public {
         uint256 id = _createSimpleContract();
         uint256 clientBefore = client.balance;
 
-        vm.prank(client);
-        trustLedger.cancelPending(id);
+        vm.prank(freelancer);
+        trustLedger.cancelProposal(id);
 
-        assertEq(client.balance, clientBefore + AMOUNT, "cancel refund mismatch");
+        // No funds are held while PENDING, so no balances change.
+        assertEq(client.balance, clientBefore, "client balance should be unchanged");
         TrustLedger.EscrowContract memory c = trustLedger.getContract(id);
         assertEq(uint8(c.status), uint8(TrustLedger.Status.CANCELLED));
     }
 
-    function test_CancelPending_OnlyClient_Reverts() public {
+    function test_CancelProposal_OnlyFreelancer_Reverts() public {
         uint256 id = _createSimpleContract();
         vm.expectRevert(TrustLedger.Unauthorized.selector);
         vm.prank(stranger);
-        trustLedger.cancelPending(id);
+        trustLedger.cancelProposal(id);
     }
 
-    function test_CancelPending_WrongStatus_Reverts() public {
+    function test_CancelProposal_WrongStatus_Reverts() public {
         uint256 id = _createAndAccept(); // already ACTIVE
         vm.expectRevert(abi.encodeWithSelector(TrustLedger.InvalidStatus.selector, TrustLedger.Status.ACTIVE));
-        vm.prank(client);
-        trustLedger.cancelPending(id);
+        vm.prank(freelancer);
+        trustLedger.cancelProposal(id);
     }
 
     // ─── Rejection
     // ────────────────────────────────────────────────────────────
 
-    function test_Rejection_RefundsClient() public {
+    function test_Rejection_ByClient() public {
         uint256 id = _createSimpleContract();
         uint256 clientBefore = client.balance;
 
-        vm.prank(freelancer);
+        vm.prank(client);
         trustLedger.rejectContract(id);
 
-        assertEq(client.balance, clientBefore + AMOUNT, "refund mismatch");
+        // No funds are held while PENDING, so nothing is refunded.
+        assertEq(client.balance, clientBefore, "client balance should be unchanged");
 
         TrustLedger.EscrowContract memory c = trustLedger.getContract(id);
         assertEq(uint8(c.status), uint8(TrustLedger.Status.CANCELLED));
@@ -369,11 +352,11 @@ contract TrustLedgerTest is Test {
     // ─── Revert Conditions
     // ────────────────────────────────────────────────────
 
-    function test_Revert_CreateContract_ZeroAddress() public {
+    function test_Revert_ProposeContract_ZeroAddress() public {
         vm.expectRevert(TrustLedger.ZeroAddress.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: AMOUNT}({
-            freelancer: address(0),
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: address(0),
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -383,15 +366,15 @@ contract TrustLedgerTest is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: AMOUNT
         });
     }
 
-    function test_Revert_CreateContract_SelfContract() public {
+    function test_Revert_ProposeContract_SelfContract() public {
         vm.expectRevert(TrustLedger.SelfContract.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: AMOUNT}({
-            freelancer: client,
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: freelancer,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -401,15 +384,15 @@ contract TrustLedgerTest is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: AMOUNT
         });
     }
 
-    function test_Revert_CreateContract_ZeroValue() public {
+    function test_Revert_ProposeContract_ZeroAmount() public {
         vm.expectRevert(TrustLedger.InsufficientFunds.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: 0}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -419,15 +402,15 @@ contract TrustLedgerTest is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: 0
         });
     }
 
-    function test_Revert_CreateContract_InvalidBufferFactor() public {
+    function test_Revert_ProposeContract_InvalidBufferFactor() public {
         vm.expectRevert(TrustLedger.InvalidBufferFactor.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: AMOUNT}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -437,15 +420,15 @@ contract TrustLedgerTest is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: AMOUNT
         });
     }
 
-    function test_Revert_CreateContract_InvalidAcceptanceWindow() public {
+    function test_Revert_ProposeContract_InvalidAcceptanceWindow() public {
         vm.expectRevert(TrustLedger.InvalidAcceptanceWindow.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: AMOUNT}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -455,15 +438,15 @@ contract TrustLedgerTest is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: AMOUNT
         });
     }
 
-    function test_Revert_CreateContract_InvalidArbitrationFee() public {
+    function test_Revert_ProposeContract_InvalidArbitrationFee() public {
         vm.expectRevert(TrustLedger.InvalidArbitrationFee.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: AMOUNT}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -473,15 +456,15 @@ contract TrustLedgerTest is Test {
             holdBackBps: 0,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: AMOUNT
         });
     }
 
-    function test_Revert_CreateContract_InvalidHoldBack() public {
+    function test_Revert_ProposeContract_InvalidHoldBack() public {
         vm.expectRevert(TrustLedger.InvalidHoldBack.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: AMOUNT}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -491,15 +474,15 @@ contract TrustLedgerTest is Test {
             holdBackBps: 100,
             warrantyPeriod: 7 days,
             token: address(0),
-            tokenAmount: 0
+            amount: AMOUNT
         });
     }
 
-    function test_Revert_CreateContract_HoldBackWithoutWarranty() public {
+    function test_Revert_ProposeContract_HoldBackWithoutWarranty() public {
         vm.expectRevert(TrustLedger.InvalidWarrantyPeriod.selector);
-        vm.prank(client);
-        trustLedger.createContract{value: AMOUNT}({
-            freelancer: freelancer,
+        vm.prank(freelancer);
+        trustLedger.proposeContract({
+            client: client,
             contractHash: CONTRACT_HASH,
             contractURI: CONTRACT_URI,
             estimatedDuration: ESTIMATED_DURATION,
@@ -509,37 +492,31 @@ contract TrustLedgerTest is Test {
             holdBackBps: 1000,
             warrantyPeriod: 0,
             token: address(0),
-            tokenAmount: 0
+            amount: AMOUNT
         });
     }
 
     function test_Revert_AcceptContract_WrongCaller() public {
         uint256 id = _createSimpleContract();
-        // Signature is valid (signed by freelancer) but msg.sender is stranger → Unauthorized.
-        (uint8 v, bytes32 r, bytes32 s) = _signAccept(id);
+        // Only the named client may accept and fund; a stranger is rejected.
         vm.expectRevert(TrustLedger.Unauthorized.selector);
         vm.prank(stranger);
-        trustLedger.acceptContract(id, v, r, s);
+        trustLedger.acceptContract{value: AMOUNT}(id);
     }
 
-    function test_Revert_AcceptContract_BadSignature() public {
+    function test_Revert_AcceptContract_WrongValue() public {
         uint256 id = _createSimpleContract();
-        // Sign with the wrong private key → ecrecover returns a different address → InvalidSignature.
-        Vm.Wallet memory wrongWallet = vm.createWallet("stranger");
-        bytes32 innerHash = keccak256(abi.encodePacked(id, freelancer));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", innerHash));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wrongWallet.privateKey, ethSignedHash);
-        vm.expectRevert(TrustLedger.InvalidSignature.selector);
-        vm.prank(freelancer);
-        trustLedger.acceptContract(id, v, r, s);
+        // Client must fund exactly the proposed amount; underfunding reverts.
+        vm.expectRevert(TrustLedger.InsufficientFunds.selector);
+        vm.prank(client);
+        trustLedger.acceptContract{value: AMOUNT - 1}(id);
     }
 
     function test_Revert_AcceptContract_WrongStatus() public {
         uint256 id = _createAndAccept(); // now ACTIVE
-        (uint8 v, bytes32 r, bytes32 s) = _signAccept(id);
         vm.expectRevert(abi.encodeWithSelector(TrustLedger.InvalidStatus.selector, TrustLedger.Status.ACTIVE));
-        vm.prank(freelancer);
-        trustLedger.acceptContract(id, v, r, s);
+        vm.prank(client);
+        trustLedger.acceptContract{value: AMOUNT}(id);
     }
 
     function test_Revert_ApproveWork_WrongCaller() public {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,9 +19,9 @@ state transition is enforced by the EVM.
   ┌──────────────────────────────────────────────────────────────────────┐
   │                        TrustLedger.sol                               │
   │                                                                      │
-  │  createContract()    ← client locks ETH or ERC-20  [whenNotPaused]  │
-  │  acceptContract()    ← freelancer signs with ECDSA (ecrecover)       │
-  │  rejectContract()    ← freelancer declines; client refunded          │
+  │  proposeContract()   ← freelancer drafts terms     [whenNotPaused]  │
+  │  acceptContract()    ← client locks ETH or ERC-20 (funds escrow)     │
+  │  rejectContract()    ← client declines; no funds held                │
   │  submitProofOfWork() ← freelancer submits IPFS hash                  │
   │  approveWork()       ← client approves; funds released               │
   │  disputeWork()       ← client disputes; fee pool forwarded ──────────┼──►
@@ -90,22 +90,22 @@ state transition is enforced by the EVM.
 ### On-Chain Flow
 
 ```text
-Client                  TrustLedger             Freelancer
+Freelancer              TrustLedger             Client
   │                         │                       │
-  │── createContract() ─────►│ (ETH locked)          │
-  │                         │─── ContractCreated ───►│
+  │── proposeContract() ────►│ (no funds yet)        │
+  │                         │─── ContractProposed ──►│
   │                         │                       │
-  │                         │◄── acceptContract(v,r,s) (ECDSA sig) ──│
-  │                         │  ecrecover verifies signer             │
+  │                         │◄── acceptContract(){value} (escrow funded) ──│
+  │                         │  client funds; deadline starts               │
   │                         │─── ContractAccepted ──►│
   │                         │                       │
-  │                         │◄── submitProofOfWork(hash, uri) ────────│
+  │── submitProofOfWork(hash, uri) ─►│              │
   │                         │  acceptanceDeadline set                │
   │                         │─── ProofSubmitted ────►│
   │                         │                       │
-  │── approveWork() ────────►│                       │
-  │                         │── FundsReleased ───────────────────────►│
-  │                         │  (amount - holdBack)                   │
+  │                         │◄────────── approveWork() ──────────────│
+  │◄── FundsReleased ───────│                       │
+  │   (amount - holdBack)   │                       │
   │                         │                       │
   │── submitRating(score) ──►│─── ReputationRegistry.rate() ──────────►│
   │                         │◄─ submitRating(score) ──────────────────│
@@ -114,47 +114,45 @@ Client                  TrustLedger             Freelancer
 
 ### Frontend Magic Link Flow (Precedes On-Chain Acceptance)
 
-The client fills in the freelancer's email on the create-contract page. After
-the `createContract` transaction confirms, the frontend extracts the contract ID
-from the `ContractCreated` event log and calls the Next.js API to send a signed
-magic link.
+The freelancer fills in the client's email on the propose-contract page. After
+the `proposeContract` transaction confirms, the frontend extracts the contract
+ID from the `ContractProposed` event log and calls the Next.js API to send a
+signed magic link to the client.
 
 ```text
-Client browser          Next.js API             Email            Freelancer browser
+Freelancer browser      Next.js API             Email            Client browser
   │                         │                      │                       │
-  │── createContract() tx ──►│ (on-chain)           │                       │
+  │── proposeContract() tx ─►│ (on-chain)           │                       │
   │   (confirms; id parsed) │                      │                       │
   │                         │                      │                       │
   │─ POST /api/magic-link/send ─────────────────────────────────────────   │
-  │   {contractId, freelancerEmail, freelancerAddress}                      │
+  │   {contractId, clientEmail, clientAddress}                              │
   │                         │                      │                       │
   │                         │ signMagicToken()      │                       │
   │                         │ (HMAC-SHA256, 72h exp)│                       │
   │                         │─── Resend email ─────►│─── link in inbox ────►│
   │◄── {ok: true} ──────────│                      │                       │
   │                         │                      │                       │
-  │                         │                      │   /freelancer/accept?token=…
+  │                         │                      │      /client/accept?token=…
   │                         │◄── GET /api/magic-link/verify?token=… ───────│
   │                         │    (HMAC + expiry check)                      │
   │                         │─── {ok, payload} ────────────────────────────►│
   │                         │                      │                       │
-  │                         │   (reads getContract on-chain)               │
+  │                         │   (reads getContract; inline decrypt-to-view)│
   │                         │                      │                       │
-  │                         │   (wallet connect prompt; must match freelancerAddress)
+  │                         │   (wallet connect prompt; must match clientAddress)
   │                         │                      │                       │
-  │                         │   signMessage(keccak256(id, freelancerAddress))
-  │                         │◄──────────────────────────────── sig (v, r, s)│
-  │                         │                      │                       │
-  │                         │◄─ acceptContract(id, v, r, s) ───────────────│
-  │                         │   (ecrecover verifies signer on-chain)       │
+  │                         │◄─ acceptContract(id){value} ─────────────────│
+  │                         │   (funds escrow; or rejectContract(id))      │
   │                         │─── ContractAccepted ─────────────────────────►│
   │                         │   project deadline timer starts              │
 ```
 
 The magic link is single-use by design: the contract's status machine
-(`PENDING → ACTIVE`) is irreversible on-chain, so a replayed token will simply
-find the contract in a non-PENDING state and the `acceptContract` call will
-revert with `InvalidStatus`. No server-side token revocation store is required.
+(`PENDING → ACTIVE`/`CANCELLED`) is irreversible on-chain, so a replayed token
+will simply find the contract in a non-PENDING state and the `acceptContract`
+call will revert with `InvalidStatus`. No server-side token revocation store is
+required.
 
 ---
 
@@ -450,12 +448,12 @@ minimize the number of slots used (and therefore gas costs).
 
 ### `TrustLedger` contract-level state (outside `EscrowContract`)
 
-| Variable             | Type                    | Description                                                 |
-| -------------------- | ----------------------- | ----------------------------------------------------------- |
-| `nextId`             | `uint256`               | Auto-incrementing escrow ID counter.                        |
-| `priceFeed`          | `AggregatorV3Interface` | Optional Chainlink ETH/USD feed.                            |
-| `reputationRegistry` | `IReputationRegistry`   | Optional reputation registry.                               |
-| `pauser`             | `address`               | Optional address allowed to pause/unpause `createContract`. |
+| Variable             | Type                    | Description                                                  |
+| -------------------- | ----------------------- | ------------------------------------------------------------ |
+| `nextId`             | `uint256`               | Auto-incrementing escrow ID counter.                         |
+| `priceFeed`          | `AggregatorV3Interface` | Optional Chainlink ETH/USD feed.                             |
+| `reputationRegistry` | `IReputationRegistry`   | Optional reputation registry.                                |
+| `pauser`             | `address`               | Optional address allowed to pause/unpause `proposeContract`. |
 
 ### `Dispute` (Arbitration)
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -21,12 +21,12 @@ freelancer and enforces the contract lifecycle.
 
 ### State
 
-| Name                 | Type                    | Description                                                                   |
-| -------------------- | ----------------------- | ----------------------------------------------------------------------------- |
-| `nextId`             | `uint256`               | Auto-incrementing escrow contract ID counter.                                 |
-| `priceFeed`          | `AggregatorV3Interface` | Optional Chainlink ETH/USD feed; zero if unset.                               |
-| `reputationRegistry` | `IReputationRegistry`   | Optional reputation registry; zero if unset.                                  |
-| `pauser`             | `address`               | Optional address authorized to pause/unpause `createContract`; zero if unset. |
+| Name                 | Type                    | Description                                                                    |
+| -------------------- | ----------------------- | ------------------------------------------------------------------------------ |
+| `nextId`             | `uint256`               | Auto-incrementing escrow contract ID counter.                                  |
+| `priceFeed`          | `AggregatorV3Interface` | Optional Chainlink ETH/USD feed; zero if unset.                                |
+| `reputationRegistry` | `IReputationRegistry`   | Optional reputation registry; zero if unset.                                   |
+| `pauser`             | `address`               | Optional address authorized to pause/unpause `proposeContract`; zero if unset. |
 
 ### Constants
 
@@ -50,15 +50,15 @@ freelancer and enforces the contract lifecycle.
 The escrow lifecycle state, stored on-chain as a `uint8`. See
 [Architecture](ARCHITECTURE.md) for the full state machine.
 
-| Value | Name        | Meaning                                                                                         |
-| ----- | ----------- | ----------------------------------------------------------------------------------------------- |
-| 0     | `PENDING`   | Contract created; freelancer has not responded yet.                                             |
-| 1     | `ACTIVE`    | Freelancer accepted; project deadline is counting down.                                         |
-| 2     | `SUBMITTED` | Freelancer submitted proof-of-work; acceptance window running.                                  |
-| 3     | `APPROVED`  | Client approved, or the acceptance window elapsed (auto-release).                               |
-| 4     | `DISPUTED`  | Client opened a dispute; awaiting arbitration.                                                  |
-| 5     | `RESOLVED`  | Arbitration finalized and the ruling was executed.                                              |
-| 6     | `CANCELLED` | Freelancer rejected, client cancelled while pending, or client reclaimed after a deadline miss. |
+| Value | Name        | Meaning                                                                                       |
+| ----- | ----------- | --------------------------------------------------------------------------------------------- |
+| 0     | `PENDING`   | Freelancer proposed terms; client has not funded/responded yet.                               |
+| 1     | `ACTIVE`    | Client accepted and funded the escrow; project deadline is counting down.                     |
+| 2     | `SUBMITTED` | Freelancer submitted proof-of-work; acceptance window running.                                |
+| 3     | `APPROVED`  | Client approved, or the acceptance window elapsed (auto-release).                             |
+| 4     | `DISPUTED`  | Client opened a dispute; awaiting arbitration.                                                |
+| 5     | `RESOLVED`  | Arbitration finalized and the ruling was executed.                                            |
+| 6     | `CANCELLED` | Client rejected, freelancer withdrew the proposal, or client reclaimed after a deadline miss. |
 
 #### `EscrowContract` struct
 
@@ -94,11 +94,11 @@ struct EscrowContract {
 
 ### Functions
 
-#### `createContract`
+#### `proposeContract`
 
 ```solidity
-function createContract(
-    address freelancer,
+function proposeContract(
+    address client,
     bytes32 contractHash,
     string calldata contractURI,
     uint256 estimatedDuration,
@@ -108,16 +108,20 @@ function createContract(
     uint16  holdBackBps,
     uint64  warrantyPeriod,
     address token,
-    uint256 tokenAmount
-) external payable returns (uint256 id)
+    uint256 amount
+) external returns (uint256 id)
 ```
 
-Creates an escrow contract and locks funds. For ETH: set `token = address(0)`,
-`tokenAmount = 0`, send ETH as `msg.value`. For ERC-20: set `token` to the token
-address, `tokenAmount` to the amount, `msg.value = 0` (pre-approve the contract
-first).
+The freelancer (caller) proposes an escrow contract. **No funds move yet** - the
+named `client` locks the escrow when they accept. For ETH escrow set
+`token = address(0)`; for ERC-20 set `token` to the token address. `amount` is
+the escrow the client will lock on acceptance (wei or token units) and must be
+non-zero. The function is non-payable.
 
-`projectDeadline = block.timestamp + (estimatedDuration × bufferFactor) / 1000`
+The project deadline counts from acceptance, not proposal: `proposeContract`
+stores the buffered duration `(estimatedDuration × bufferFactor) / 1000`, and
+`acceptContract` converts it to an absolute
+`projectDeadline = block.timestamp + bufferedDuration` when the client funds.
 
 Reverts with `EnforcedPause` when the contract is paused. Call `unpause()`
 first.
@@ -130,20 +134,24 @@ pointer. `contractURI` must be a non-empty IPFS URI (e.g. `ipfs://<CID>`); both
 are required - passing a zero hash or empty URI reverts with `EmptyHash` or
 `EmptyURI`.
 
-Emits `ContractCreated`.
+Emits `ContractProposed`.
 
 ---
 
 #### `acceptContract`
 
 ```solidity
-function acceptContract(uint256 id, uint8 v, bytes32 r, bytes32 s) external
+function acceptContract(uint256 id) external payable
 ```
 
-Freelancer accepts the contract by submitting an EIP-191 ECDSA signature over
-`keccak256(abi.encodePacked(id, freelancerAddress))`. The contract recovers the
-signer and reverts if it does not match `freelancer`. Transitions status to
-`ACTIVE`.
+The client (caller) accepts the freelancer's proposal and funds the escrow in
+the same transaction - the funding transaction is the client's consent, so no
+separate signature is required. For ETH escrow send `msg.value == amount`; for
+ERC-20 send no ETH and pre-approve the contract for `amount`, which is pulled
+via `transferFrom`. Reverts with `Unauthorized` if the caller is not the client,
+`InsufficientFunds` if `msg.value` does not equal the proposed amount, or
+`InvalidTokenParams` if ETH is sent with a token escrow. Transitions status to
+`ACTIVE` and starts the project deadline.
 
 Emits `ContractAccepted`.
 
@@ -155,8 +163,8 @@ Emits `ContractAccepted`.
 function rejectContract(uint256 id) external
 ```
 
-Freelancer rejects the contract. Funds are returned to the client. Status
-transitions to `CANCELLED`.
+The client rejects the freelancer's proposal. No funds are held while `PENDING`,
+so nothing is transferred. Status transitions to `CANCELLED`.
 
 Emits `ContractRejected`.
 
@@ -250,14 +258,15 @@ Emits `WarrantyFundsClaimed`.
 
 ---
 
-#### `cancelPending`
+#### `cancelProposal`
 
 ```solidity
-function cancelPending(uint256 id) external
+function cancelProposal(uint256 id) external
 ```
 
-Client cancels a contract that is still `PENDING` (before the freelancer
-responds). Funds returned to client. Status transitions to `CANCELLED`.
+The freelancer withdraws their own `PENDING` proposal (before the client funds
+it). No funds are held, so nothing is transferred. Status transitions to
+`CANCELLED`.
 
 Emits `ContractCancelled`.
 
@@ -269,15 +278,15 @@ Emits `ContractCancelled`.
 function linkAmendment(uint256 newId, uint256 previousId) external
 ```
 
-Links a `PENDING` replacement contract to its `CANCELLED` predecessor,
+Links a `PENDING` replacement proposal to its `CANCELLED` predecessor,
 establishing an on-chain amendment version history. The caller must be the
-client on both contracts. `previousId` must be `CANCELLED`; `newId` must be
+freelancer on both contracts. `previousId` must be `CANCELLED`; `newId` must be
 `PENDING` and not already linked.
 
 Amendment flow:
 
-1. `cancelPending(oldId)` - invalidates the existing contract, returns funds.
-2. `createContract(...)` - creates the replacement with updated terms and a new
+1. `cancelProposal(oldId)` - withdraws the existing proposal.
+2. `proposeContract(...)` - creates the replacement with updated terms and a new
    `contractHash`.
 3. `linkAmendment(newId, oldId)` - records the on-chain link; the
    `previousContractId` field on the new contract becomes `oldId`.
@@ -368,10 +377,11 @@ is permanently unavailable.
 function pause() external
 ```
 
-Pauses `createContract`, blocking new escrows from being opened. All in-flight
-lifecycle functions (`acceptContract`, `submitProofOfWork`, `approveWork`,
-`disputeWork`, claim functions) remain active so that funds already in escrow
-can always exit. Reverts with `NotPauser` if the caller is not `pauser`.
+Pauses `proposeContract`, blocking new escrows from being proposed. All
+in-flight lifecycle functions (`acceptContract`, `submitProofOfWork`,
+`approveWork`, `disputeWork`, claim functions) remain active so that funds
+already in escrow can always exit. Reverts with `NotPauser` if the caller is not
+`pauser`.
 
 Emits `Paused` (OpenZeppelin standard event).
 
@@ -383,7 +393,7 @@ Emits `Paused` (OpenZeppelin standard event).
 function unpause() external
 ```
 
-Restores `createContract` to normal operation. Reverts with `NotPauser` if the
+Restores `proposeContract` to normal operation. Reverts with `NotPauser` if the
 caller is not `pauser`.
 
 Emits `Unpaused` (OpenZeppelin standard event).
@@ -404,7 +414,7 @@ Returns the full `EscrowContract` struct for a given escrow ID.
 
 | Event                  | Parameters                             |
 | ---------------------- | -------------------------------------- |
-| `ContractCreated`      | `id`, `client`, `freelancer`, `amount` |
+| `ContractProposed`     | `id`, `client`, `freelancer`, `amount` |
 | `ContractAccepted`     | `id`                                   |
 | `ContractRejected`     | `id`                                   |
 | `ProofSubmitted`       | `id`, `powHash`, `powURI`              |
@@ -419,34 +429,33 @@ Returns the full `EscrowContract` struct for a given escrow ID.
 
 ### Errors
 
-| Error                     | Trigger                                                              |
-| ------------------------- | -------------------------------------------------------------------- |
-| `Unauthorized`            | Caller is not the expected party for this action.                    |
-| `InvalidStatus`           | Contract is not in the required state.                               |
-| `DeadlineNotElapsed`      | Project deadline has not passed yet.                                 |
-| `DeadlineElapsed`         | Project deadline has already passed.                                 |
-| `WindowNotElapsed`        | Acceptance or warranty window has not expired.                       |
-| `WindowElapsed`           | Acceptance window has already closed.                                |
-| `InvalidBufferFactor`     | Buffer factor is below the minimum of 1.1×.                          |
-| `InvalidAcceptanceWindow` | Acceptance window is below 48 hours.                                 |
-| `InvalidArbitrationFee`   | Fee is zero or exceeds 50%.                                          |
-| `InvalidHoldBack`         | Hold-back is outside the allowed range.                              |
-| `InvalidWarrantyPeriod`   | Hold-back and warranty period must both be set or both be zero.      |
-| `InsufficientFunds`       | No ETH sent for ETH escrow, or no token amount for ERC-20 escrow.    |
-| `ZeroAddress`             | Freelancer address is the zero address.                              |
-| `SelfContract`            | Client cannot hire themselves.                                       |
-| `EthTransferFailed`       | Low-level ETH transfer returned false.                               |
-| `TokenTransferFailed`     | ERC-20 transfer returned false.                                      |
-| `InvalidTokenParams`      | Mismatch between token field and funding (e.g. ETH sent with token). |
-| `InvalidSignature`        | ECDSA recovery does not match the freelancer's address.              |
-| `RatingOutOfRange`        | Score is outside 1-100.                                              |
-| `RatingAlreadySubmitted`  | This party has already rated for this contract.                      |
-| `ContractNotFinished`     | Contract has not reached `APPROVED` or `RESOLVED`.                   |
-| `AlreadySet`              | One-time setter was already called.                                  |
-| `NotPauser`               | Caller is not the designated pauser address.                         |
-| `EmptyHash`               | `contractHash` or `proofOfWorkHash` is `bytes32(0)`.                 |
-| `EmptyURI`                | `contractURI` or `proofOfWorkURI` is an empty string.                |
-| `InvalidPreviousContract` | `previousId` is not `CANCELLED`, or caller is not its client.        |
+| Error                     | Trigger                                                                  |
+| ------------------------- | ------------------------------------------------------------------------ |
+| `Unauthorized`            | Caller is not the expected party for this action.                        |
+| `InvalidStatus`           | Contract is not in the required state.                                   |
+| `DeadlineNotElapsed`      | Project deadline has not passed yet.                                     |
+| `DeadlineElapsed`         | Project deadline has already passed.                                     |
+| `WindowNotElapsed`        | Acceptance or warranty window has not expired.                           |
+| `WindowElapsed`           | Acceptance window has already closed.                                    |
+| `InvalidBufferFactor`     | Buffer factor is below the minimum of 1.1×.                              |
+| `InvalidAcceptanceWindow` | Acceptance window is below 48 hours.                                     |
+| `InvalidArbitrationFee`   | Fee is zero or exceeds 50%.                                              |
+| `InvalidHoldBack`         | Hold-back is outside the allowed range.                                  |
+| `InvalidWarrantyPeriod`   | Hold-back and warranty period must both be set or both be zero.          |
+| `InsufficientFunds`       | Proposed amount is zero, or `msg.value` ≠ the proposed amount on accept. |
+| `ZeroAddress`             | Client address is the zero address.                                      |
+| `SelfContract`            | Freelancer cannot propose a contract to themselves as client.            |
+| `EthTransferFailed`       | Low-level ETH transfer returned false.                                   |
+| `TokenTransferFailed`     | ERC-20 transfer returned false.                                          |
+| `InvalidTokenParams`      | Mismatch between token field and funding (e.g. ETH sent with token).     |
+| `RatingOutOfRange`        | Score is outside 1-100.                                                  |
+| `RatingAlreadySubmitted`  | This party has already rated for this contract.                          |
+| `ContractNotFinished`     | Contract has not reached `APPROVED` or `RESOLVED`.                       |
+| `AlreadySet`              | One-time setter was already called.                                      |
+| `NotPauser`               | Caller is not the designated pauser address.                             |
+| `EmptyHash`               | `contractHash` or `proofOfWorkHash` is `bytes32(0)`.                     |
+| `EmptyURI`                | `contractURI` or `proofOfWorkURI` is an empty string.                    |
+| `InvalidPreviousContract` | `previousId` is not `CANCELLED`, or caller is not its freelancer.        |
 
 ---
 
@@ -1012,56 +1021,42 @@ the `keccak256` of the actual file bytes (computed off-chain before upload) and
 non-zero, and `contractURI`/`proofOfWorkURI` must be non-empty IPFS URIs.
 Zero/empty values revert with `EmptyHash` / `EmptyURI`.
 
-### Happy path (client creates → freelancer accepts → submits → client approves)
+### Happy path (propose → accept & fund → submit → approve)
 
 ```bash
 TL=0x...                       # TrustLedger address
 RPC=$SEPOLIA_RPC_URL
-FREELANCER=0x...
+CLIENT=0x...
 HASH=$(cast keccak "$(cat agreement.pdf)")   # keccak256 of the document bytes
 
-# 1. Client creates a 0.5 ETH escrow.
-#    args: freelancer, contractHash, contractURI, estimatedDuration (7d),
+# 1. Freelancer proposes a 0.5 ETH escrow (no funds move yet).
+#    args: client, contractHash, contractURI, estimatedDuration (7d),
 #          bufferFactor (1.1x), acceptanceWindow (48h), arbitrationFeeBps (5%),
-#          holdBackBps (10%), warrantyPeriod (14d), token (ETH=0), tokenAmount (0)
+#          holdBackBps (10%), warrantyPeriod (14d), token (ETH=0), amount (0.5e18)
 cast send "$TL" \
-  "createContract(address,bytes32,string,uint256,uint256,uint256,uint16,uint16,uint64,address,uint256)" \
-  "$FREELANCER" "$HASH" "ipfs://<CID>" \
+  "proposeContract(address,bytes32,string,uint256,uint256,uint256,uint16,uint16,uint64,address,uint256)" \
+  "$CLIENT" "$HASH" "ipfs://<CID>" \
   604800 1100 172800 500 1000 1209600 \
-  0x0000000000000000000000000000000000000000 0 \
-  --value 0.5ether --rpc-url "$RPC" --private-key "$CLIENT_KEY"
-# -> emits ContractCreated(id, client, freelancer, amount); first id is 1
+  0x0000000000000000000000000000000000000000 500000000000000000 \
+  --rpc-url "$RPC" --private-key "$FREELANCER_KEY"
+# -> emits ContractProposed(id, client, freelancer, amount); first id is 1
 ```
 
-The freelancer accepts with a wallet signature over
-`keccak256(abi.encodePacked(id, freelancerAddress))`, signed with the EIP-191
-prefix (`eth_sign` / `personal_sign`). viem applies the prefix automatically
-when signing a `raw` hash:
+The client accepts by funding the escrow in the same transaction - the funding
+transaction itself is consent, so no signature is needed:
 
 ```ts
-import {
-    createWalletClient,
-    http,
-    encodePacked,
-    keccak256,
-    hexToSignature,
-} from "viem";
+import { createWalletClient, http, parseEther } from "viem";
 
 const id = 1n;
-const innerHash = keccak256(
-    encodePacked(["uint256", "address"], [id, freelancer]),
-);
-const signature = await walletClient.signMessage({
-    message: { raw: innerHash },
-});
-const { v, r, s } = hexToSignature(signature);
 
-// 2. Freelancer accepts -> status ACTIVE
+// 2. Client accepts -> escrow funded, status ACTIVE
 await walletClient.writeContract({
     address: TL,
     abi,
     functionName: "acceptContract",
-    args: [id, Number(v), r, s],
+    args: [id],
+    value: parseEther("0.5"),
 });
 ```
 
@@ -1127,7 +1122,7 @@ import { parseAbiItem } from "viem";
 const logs = await publicClient.getLogs({
     address: TL,
     event: parseAbiItem(
-        "event ContractCreated(uint256 indexed id, address indexed client, address indexed freelancer, uint256 amount)",
+        "event ContractProposed(uint256 indexed id, address indexed client, address indexed freelancer, uint256 amount)",
     ),
     fromBlock: deployBlock,
 });

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -99,8 +99,8 @@ docker compose up demo-good
 Starts the Hardhat node, deploys all three contracts, then runs the happy-path
 demo:
 
-1. Client deposits 1 ETH into escrow.
-2. Freelancer signs acceptance (ECDSA wallet binding).
+1. Freelancer proposes a 1 ETH escrow.
+2. Client accepts, depositing 1 ETH into escrow.
 3. Freelancer submits proof of work (IPFS hash).
 4. Client approves → **1 ETH released to freelancer.**
 
@@ -162,7 +162,7 @@ Starts the node, deploys (including `ReputationRegistry`), then runs
 `scripts/demo/demo-stablecoin.ts`:
 
 1. Deploys a `MockERC20` stablecoin and mints tokens to the client.
-2. Gas benchmark: `createContract` with ETH vs ERC-20 escrow.
+2. Gas benchmark: `proposeContract` with ETH vs ERC-20 escrow.
 3. Full happy path on token escrow (accept → submit → approve).
 4. Both parties call `submitRating`; scores read back from `ReputationRegistry`.
 
@@ -288,15 +288,15 @@ types. Balance diffs are verified at each payout step.
 | Group                  | What it covers                                                                                     |
 | ---------------------- | -------------------------------------------------------------------------------------------------- |
 | Deployment             | Contract addresses and immutable references wired correctly                                        |
-| Happy path             | Create → accept (ECDSA signature) → submit proof of work → approve → full ETH payout               |
-| Cancel pending         | Client cancels before freelancer accepts; full refund verified by balance diff                     |
-| Rejection              | Freelancer rejects; client refunded; status set to `CANCELLED`                                     |
+| Happy path             | Propose → accept (client funds escrow) → submit proof of work → approve → full ETH payout          |
+| Cancel proposal        | Freelancer withdraws proposal before funding; no funds held; status set to `CANCELLED`             |
+| Rejection              | Client rejects proposal; no funds held; status set to `CANCELLED`                                  |
 | Deadline miss          | Client reclaims escrow after project deadline passes                                               |
 | Acceptance window      | Freelancer auto-claims release after acceptance window elapses via `evm_increaseTime`              |
 | Hold-back and warranty | Partial payout on approval; warranty clock; full release after period                              |
 | Dispute flow           | Fee pool transferred to `Arbitration`; status set to `DISPUTED`; dispute opened on-chain           |
 | `executeRuling`        | 0%, 100%, and 50% split payouts each verified by balance diff                                      |
-| Revert cases           | Invalid inputs: zero address, self-contract, bad signature, wrong caller, wrong status             |
+| Revert cases           | Invalid inputs: zero address, self-contract, zero/wrong amount, wrong caller, wrong status         |
 | ERC-20 escrow          | Full lifecycle (create, approve, reject, cancel, warranty, dispute, ruling) with token not ETH     |
 | Chainlink price feed   | USD value stored on creation; zero when price feed returns ≤ 0; double-init reverts                |
 | VRF mock               | VRF randomness requested on dispute open; jurors pre-selected; non-VRF commits rejected            |
@@ -309,15 +309,15 @@ types. Balance diffs are verified at each payout step.
 Solidity-native tests targeting `TrustLedger.sol` using Foundry `vm` cheatcodes
 for time travel, address pranking, and revert matching.
 
-| Group              | What it covers                                                                                                         |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| Happy path         | Create/accept/submit/approve with and without hold-back                                                                |
-| Cancel / reject    | Refund paths and status transitions                                                                                    |
-| Deadline / window  | Client reclaim and auto-release flows                                                                                  |
-| Dispute and ruling | Fee pool routing; 0%, 50%, and 100% payout splits                                                                      |
-| Payout math        | Fuzz over `completionPct`: client + freelancer receipts always equal escrowed total                                    |
-| Revert guards      | All invalid-input paths across `createContract`, `acceptContract`, `approveWork`, `executeRuling`, `submitProofOfWork` |
-| Ancillary          | Rating no-op when registry unset; `nextId` increments after each creation                                              |
+| Group              | What it covers                                                                                                          |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Happy path         | Create/accept/submit/approve with and without hold-back                                                                 |
+| Cancel / reject    | Refund paths and status transitions                                                                                     |
+| Deadline / window  | Client reclaim and auto-release flows                                                                                   |
+| Dispute and ruling | Fee pool routing; 0%, 50%, and 100% payout splits                                                                       |
+| Payout math        | Fuzz over `completionPct`: client + freelancer receipts always equal escrowed total                                     |
+| Revert guards      | All invalid-input paths across `proposeContract`, `acceptContract`, `approveWork`, `executeRuling`, `submitProofOfWork` |
+| Ancillary          | Rating no-op when registry unset; `nextId` increments after each creation                                               |
 
 #### `JurorRegistryTest.t.sol` - Foundry unit tests (22 tests)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -38,17 +38,21 @@ protocol.
 
 ## For clients
 
-### How do I hire a freelancer?
+### How do I engage a client?
 
-Call `createContract(...)` (or use the dashboard), which locks your funds and
-records the freelancer address, the off-chain agreement's `keccak256` hash, and
-an IPFS URI. See the [happy-path example](CONTRACTS.md#example-interactions).
+As a freelancer, call `proposeContract(...)` (or use the dashboard) to draft the
+terms: the client address, the off-chain agreement's `keccak256` hash, an IPFS
+URI, and the escrow amount. No funds move until the client accepts and funds the
+escrow with `acceptContract(...)`. See the
+[happy-path example](CONTRACTS.md#example-interactions).
 
-### What happens if the freelancer never responds?
+### What happens if the client never funds the proposal?
 
-While the contract is still `PENDING`, you can call `cancelPending(id)` to
-reclaim your funds. If the freelancer accepted but then misses the project
-deadline without submitting work, call `claimAfterDeadlineMiss(id)`.
+While the contract is still `PENDING`, the freelancer can call
+`cancelProposal(id)` to withdraw it (no funds are held), and the client may
+`rejectContract(id)`. If the client funded the escrow but the freelancer then
+misses the project deadline without submitting work, the client calls
+`claimAfterDeadlineMiss(id)`.
 
 ### What if I'm not happy with the delivered work?
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -28,10 +28,11 @@ voting.
 
 ## How It Works
 
-1. **Client creates a contract** - locks ETH into escrow, specifies the
-   freelancer wallet and off-chain agreement (IPFS hash stored on-chain).
-2. **Freelancer accepts** - signs via ECDSA wallet binding; the contract
-   recovers the signer on-chain and rejects any mismatch.
+1. **Freelancer proposes a contract** - specifies the client wallet, the escrow
+   amount, and the off-chain agreement (IPFS hash stored on-chain). No funds
+   move yet.
+2. **Client accepts** - reviews the terms and funds the escrow in the same
+   transaction; the funding transaction is the client's on-chain consent.
 3. **Freelancer submits work** - posts an IPFS hash of the deliverable on-chain
    as immutable proof.
 4. **Client approves or disputes** - approval releases funds; a dispute opens a
@@ -47,8 +48,8 @@ voting.
 
 - **Immutable proof of agreement and deliverable** - keccak256 hashes stored
   on-chain, tampering is immediately detectable
-- **ECDSA wallet binding** - freelancers accept contracts with their private key
-  via EIP-191 signatures
+- **Accept-to-fund handshake** - the freelancer proposes terms and the client
+  commits by funding the escrow; no funds are held before mutual consent
 - **Commit-reveal voting** - votes are hidden during the commit phase to prevent
   herding
 - **Chainlink VRF juror selection** - verifiable randomness selects jurors at

--- a/docs/MISCELLANEOUS.md
+++ b/docs/MISCELLANEOUS.md
@@ -156,7 +156,7 @@ set, a JWT input field is shown in the UI at runtime.
 After upload the IPFS URI is auto-filled into the form, and `contractHash` is
 computed from the uploaded bytes - not the URI string - so on-chain tamper
 detection covers actual file content. Both the hash and the URI are **required
-by the contract**: `createContract` reverts with `EmptyHash` if
+by the contract**: `proposeContract` reverts with `EmptyHash` if
 `contractHash == bytes32(0)` and `EmptyURI` if `contractURI` is empty. The same
 enforcement applies to `submitProofOfWork` - `powHash` and `powURI` must both be
 provided. The UI computes the hash client-side before the Pinata upload so the
@@ -181,36 +181,36 @@ upload and can be noted alongside the IPFS URI.
 
 ---
 
-### Magic Link (Freelancer Email Onboarding)
+### Magic Link (Client Email Onboarding)
 
-When a client creates a contract and provides the freelancer's email address,
+When a freelancer proposes a contract and provides the client's email address,
 the frontend automatically sends a signed magic link after the transaction
-confirms. The link lets the freelancer review the contract and accept it through
-a browser without needing prior wallet setup.
+confirms. The link lets the client review the contract, securely view the
+(optionally encrypted) document, and accept or reject it through a browser.
 
 **Flow:**
 
-1. Client fills in `Freelancer Email` on the create-contract page.
-2. After `createContract` confirms on-chain, the frontend parses the
-   `ContractCreated` event log to extract the contract ID, then calls
+1. Freelancer fills in `Client Email` on the propose-contract page.
+2. After `proposeContract` confirms on-chain, the frontend parses the
+   `ContractProposed` event log to extract the contract ID, then calls
    `POST /api/magic-link/send`.
-3. The API generates an HMAC-SHA256 token (payload: `contractId`,
-   `freelancerEmail`, `freelancerAddress`, `nonce`, 72-hour expiry) and sends an
-   HTML email via Resend.
-4. Freelancer opens `/freelancer/accept?token=…` in their browser.
+3. The API generates an HMAC-SHA256 token (payload: `contractId`, `clientEmail`,
+   `clientAddress`, `nonce`, 72-hour expiry) and sends an HTML email via Resend.
+4. Client opens `/client/accept?token=…` in their browser.
 5. The page calls `GET /api/magic-link/verify` to validate the HMAC signature
    and expiry server-side.
 6. The page reads the contract from chain via `getContract`, shows the terms,
-   and prompts wallet connection.
-7. The connected wallet must match `freelancerAddress` encoded in the token -
+   and offers an inline AES-256-GCM decrypt panel to view encrypted documents
+   before deciding, then prompts wallet connection.
+7. The connected wallet must match `clientAddress` encoded in the token -
    mismatches are blocked.
-8. The freelancer signs
-   `keccak256(abi.encodePacked(contractId, freelancerAddress))` via
-   `signMessage` (EIP-191 personal sign).
-9. The page extracts `v, r, s` from the signature and calls
-   `acceptContract(id, v, r, s)` on-chain.
-10. The contract transitions `PENDING → ACTIVE`; the project deadline timer
-    starts.
+8. To accept, the client calls `acceptContract(id)` with `value` equal to the
+   proposed amount (ERC-20 escrows pre-approve instead); the funding transaction
+   is the client's consent, so no separate signature is required. To decline,
+   the client calls `rejectContract(id)`.
+9. On acceptance the contract transitions `PENDING → ACTIVE`, the escrow is
+   funded, and the project deadline timer starts; on rejection it moves to
+   `CANCELLED` with no funds moved.
 
 **Single-use guarantee:** The token carries no server-side revocation state.
 Idempotency comes entirely from the contract's irreversible status machine - a
@@ -292,21 +292,21 @@ where the freelance market has the most liquidity and lowest gas costs at launch
 time. Foundry deploy scripts accept `--rpc-url` as a parameter, so switching
 chains requires only changing the network flag.
 
-**Contract amendment via invalidation and replacement.** When a client needs to
-renegotiate terms before the freelancer has accepted, the amendment flow is:
-`cancelPending(oldId)` → `createContract(...)` → `linkAmendment(newId, oldId)`.
-This produces a permanent on-chain version chain: each contract stores
-`previousContractId` pointing to its cancelled predecessor (`type(uint256).max`
-= original). The amendment history is fully reconstructable from events
-(`ContractCancelled` + `ContractAmended`) without any trusted intermediary.
-Amendments are only possible while the contract is `PENDING` - once a freelancer
-accepts (`ACTIVE`), renegotiation requires mutual off-chain agreement and a new
-contract from scratch.
+**Contract amendment via invalidation and replacement.** When a freelancer needs
+to revise terms before the client has funded, the amendment flow is:
+`cancelProposal(oldId)` → `proposeContract(...)` →
+`linkAmendment(newId, oldId)`. This produces a permanent on-chain version chain:
+each contract stores `previousContractId` pointing to its cancelled predecessor
+(`type(uint256).max` = original). The amendment history is fully reconstructable
+from events (`ContractCancelled` + `ContractAmended`) without any trusted
+intermediary. Amendments are only possible while the contract is `PENDING` -
+once the client accepts (`ACTIVE`), renegotiation requires mutual off-chain
+agreement and a new contract from scratch.
 
 **Minimal privileged role - pauser only.** There is no `owner` or `admin` role
 in any contract. The only privilege is the optional `pauser` address on
-`TrustLedger`, set once via `initPauser()`. It can pause `createContract` to
-block new deposits during an incident, but cannot touch funds already in
+`TrustLedger`, set once via `initPauser()`. It can pause `proposeContract` to
+block new proposals during an incident, but cannot touch funds already in
 escrow - all lifecycle exits remain open. If `initPauser` is never called, pause
 is permanently unavailable. Every other state transition is fully on-chain and
 permissionless from the participants' perspective.

--- a/docs/PRESENTATION.md
+++ b/docs/PRESENTATION.md
@@ -47,7 +47,7 @@ staked jurors votes on a completion percentage, and funds split accordingly.
            ▼
   ┌─────────────────────────────────────────────────────┐
   │                   TrustLedger.sol                   │
-  │  createContract()  acceptContract()  approveWork()  │
+  │  proposeContract()  acceptContract()  approveWork() │
   │  submitProofOfWork()  disputeWork()  executeRuling()│
   └────────────┬───────────────────────────────┬────────┘
                │ openDispute() / executeRuling()│ submitRating()
@@ -145,24 +145,22 @@ string  proofOfWorkURI;   // ipfs://Qm...
 
 ---
 
-## Feature: ECDSA Wallet Binding
+## Feature: Accept-to-Fund Handshake
 
-A freelancer cannot be enrolled in a contract without explicit cryptographic
-consent from their private key. A third party cannot accept on their behalf.
-
-The contract requires `ecrecover` to return the freelancer's address before
-advancing to `ACTIVE`. The signed message is
-`keccak256(contractId, freelancerAddress)`, which binds the signature to one
-specific contract. The EIP-191 prefix prevents replay attacks and malformed
-transaction reuse.
+The freelancer proposes the terms; the client commits by funding the escrow.
+Neither party is bound until both have acted, and no funds are ever held before
+mutual consent. The funding transaction itself is the client's on-chain consent,
+so no separate signature is needed - and only the named client can fund it.
 
 ```solidity
-bytes32 innerHash = keccak256(abi.encodePacked(id, c.freelancer));
-bytes32 ethSignedHash = keccak256(
-    abi.encodePacked("\x19Ethereum Signed Message:\n32", innerHash)
-);
-address signer = ecrecover(ethSignedHash, v, r, s);
-if (signer != c.freelancer) revert InvalidSignature();
+function acceptContract(uint256 id) external payable nonReentrant {
+    EscrowContract storage c = _contracts[id];
+    if (msg.sender != c.client) revert Unauthorized();
+    if (c.status != Status.PENDING) revert InvalidStatus(c.status);
+    if (c.token == address(0) && msg.value != c.amount) revert InsufficientFunds();
+    // ... pulls ERC-20 via transferFrom for token escrows ...
+    c.status = Status.ACTIVE; // escrow funded; deadline starts
+}
 ```
 
 ---
@@ -355,9 +353,9 @@ parties can always prove what the agreed dollar value was, regardless of what
 ETH does afterward.
 
 `TrustLedger.initPriceFeed()` wires in a `AggregatorV3Interface` once. In
-`createContract()`, `_queryUsdValue()` calls `priceFeed.latestRoundData()` and
-stores the result in `usdValueAtCreation`. Units are Chainlink's standard 8
-decimal places (`$1 = 1e8`).
+`acceptContract()`, `_queryUsdValue()` calls `priceFeed.latestRoundData()` and
+stores the result in `usdValueAtCreation` when the escrow is funded. Units are
+Chainlink's standard 8 decimal places (`$1 = 1e8`).
 
 ---
 
@@ -421,8 +419,8 @@ Each scenario runs the same 12-step flow:
 ```text
 Step  1  Register jurors (0.1 ETH stake each)
 Step  2  Fast-forward 7 days (stake lock period, EVM time-travel)
-Step  3  Client creates 1 ETH escrow
-Step  4  Freelancer accepts (ECDSA wallet binding) + submits proof of work
+Step  3  Freelancer proposes 1 ETH escrow
+Step  4  Client accepts (funds escrow); freelancer submits proof of work
 Step  5  Client opens dispute
 Step  6  Jurors commit hidden votes (commit-reveal)
 Step  7  Advance to reveal phase (all 3 committed)
@@ -523,7 +521,7 @@ Both toolchains are available as npm scripts - no need to call `forge` or
 | ------------------------------ | ------------------------- | ----------------- | -------------------- | ------------------- |
 | Decentralized                  | ✅ Fully                  | ✅ Fully          | ❌ Centralized       | ❌ Centralized      |
 | Partial-completion payouts     | ✅ Median % ruling        | ❌ Binary verdict | ❌ Manual            | ❌ Manual           |
-| ECDSA wallet binding           | ✅ On-chain ecrecover     | ❌ No             | ❌ No                | ❌ No               |
+| Accept-to-fund handshake       | ✅ Client funds on accept | ❌ No             | ❌ No                | ❌ No               |
 | Verifiable random juror select | ✅ Chainlink VRF          | ❌ Token-weighted | ❌ No                | ❌ No               |
 | Proportional fee split         | ✅ Shared by %            | ❌ Loser pays     | ❌ Flat platform fee | ❌ 20% always       |
 | Warranty hold-back             | ✅ 5-15% configurable     | ❌ No             | ❌ No                | ❌ No               |
@@ -534,8 +532,9 @@ Both toolchains are available as npm scripts - no need to call `forge` or
 | Open source                    | ✅ Apache-2.0             | ✅ MIT            | ❌ Proprietary       | ❌ Proprietary      |
 
 **The key differentiator:** TrustLedger is the only protocol with
-partial-completion rulings, proportional fee sharing, ECDSA wallet binding, and
-a warranty hold-back mechanism combined in one permissionless smart contract.
+partial-completion rulings, proportional fee sharing, an accept-to-fund
+handshake, and a warranty hold-back mechanism combined in one permissionless
+smart contract.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -68,7 +68,10 @@ flows as the Foundry unit tests but exercised via the TypeScript API.
 
 - `deployContracts()` - deploys all five contracts fresh; called in
   `beforeEach`.
-- `createContract(opts?)` - creates a contract and returns its `contractId`.
+- `createContract(opts?)` - the freelancer proposes a contract and returns its
+  `contractId` (no funds locked yet).
+- `createAndAccept(opts?)` - proposes, then the client accepts and funds the
+  escrow.
 - `createAcceptAndSubmit(opts?)` - runs the full happy path up to SUBMITTED
   status.
 - `impersonate(addr)` - wraps `hardhat_impersonateAccount` + `ethers.getSigner`.
@@ -81,8 +84,8 @@ flows as the Foundry unit tests but exercised via the TypeScript API.
 - Time is manipulated with `hardhat_mine` / `evm_increaseTime` JSON-RPC calls
   instead of `vm.warp()`.
 - All on-chain integers are `BigInt` (ethers v6); never mix with `number`.
-- `acceptContract` requires a real ECDSA signature computed with
-  `wallet.signMessage`.
+- `acceptContract` is called by the client with `{ value: amount }` to fund the
+  escrow (ERC-20 escrows approve first); no signature is involved.
 - `expect(...).to.emit(...)` replaces `assertEq` / `assertTrue`.
 
 ### Running a single test

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -28,7 +28,7 @@ const config: HardhatUserConfig = {
 				// higher = smaller per-call gas, larger deploy size
 			},
 			// viaIR compiles through Yul IR, which avoids "stack too deep" errors
-			// that arise when a function has many local variables (e.g. createContract).
+			// that arise when a function has many local variables (e.g. proposeContract).
 			viaIR: true,
 		},
 	},

--- a/scripts/demo/demo-bad.ts
+++ b/scripts/demo/demo-bad.ts
@@ -79,10 +79,10 @@ async function main(): Promise<void> {
 	console.log("  ✓ Jurors now eligible to vote");
 	console.log();
 
-	// ── Step 3: Create a 1 ETH escrow ─────────────────────────────────────────
-	console.log("Step 3 - Client creates a 1 ETH escrow...");
-	const createTx = await tl.connect(client).createContract(
-		await freelancer.getAddress(),
+	// ── Step 3: Propose a 1 ETH escrow ────────────────────────────────────────
+	console.log("Step 3 - Freelancer proposes a 1 ETH escrow...");
+	const createTx = await tl.connect(freelancer).proposeContract(
+		await client.getAddress(),
 		ethers.keccak256(ethers.toUtf8Bytes("contract-v2")),
 		"ipfs://QmDemo2",
 		30 * 24 * 3600, // 30-day estimated duration
@@ -92,11 +92,10 @@ async function main(): Promise<void> {
 		0,
 		0, // no hold-back
 		ethers.ZeroAddress,
-		0n,
-		{ value: ethers.parseEther("1") },
+		ethers.parseEther("1"), // escrow amount the client will lock
 	);
 	const createReceipt = await createTx.wait();
-	if (createReceipt === null) throw new Error("createContract tx not mined");
+	if (createReceipt === null) throw new Error("proposeContract tx not mined");
 
 	const createEvent = createReceipt.logs
 		.map((log): LogDescription | null => {
@@ -106,20 +105,17 @@ async function main(): Promise<void> {
 				return null;
 			}
 		})
-		.find((e): e is LogDescription => e !== null && e.name === "ContractCreated");
-	if (createEvent === undefined) throw new Error("ContractCreated event not found");
+		.find((e): e is LogDescription => e !== null && e.name === "ContractProposed");
+	if (createEvent === undefined) throw new Error("ContractProposed event not found");
 	const contractId = createEvent.args[0] as bigint;
 	console.log(`  ✓ Contract ID : ${contractId.toString()}`);
 	console.log();
 
-	// ── Step 4: Freelancer accepts & submits proof of work ────────────────────
-	console.log("Step 4 - Freelancer accepts & submits proof of work...");
-	const innerHash = ethers.solidityPackedKeccak256(
-		["uint256", "address"],
-		[contractId, await freelancer.getAddress()],
-	);
-	const sig = ethers.Signature.from(await freelancer.signMessage(ethers.getBytes(innerHash)));
-	await (await tl.connect(freelancer).acceptContract(contractId, sig.v, sig.r, sig.s)).wait();
+	// ── Step 4: Client accepts (funds escrow) & freelancer submits proof of work ──
+	console.log("Step 4 - Client funds escrow; freelancer submits proof of work...");
+	await (
+		await tl.connect(client).acceptContract(contractId, { value: ethers.parseEther("1") })
+	).wait();
 	await (
 		await tl
 			.connect(freelancer)

--- a/scripts/demo/demo-good.ts
+++ b/scripts/demo/demo-good.ts
@@ -39,10 +39,10 @@ async function main(): Promise<void> {
 
 	const tl = (await ethers.getContractAt("TrustLedger", TRUST_LEDGER)) as unknown as TrustLedger;
 
-	// ── Step 1: Client creates a 1 ETH escrow ─────────────────────────────────
-	console.log("Step 1 - Client creates a 1 ETH escrow...");
-	const createTx = await tl.connect(client).createContract(
-		await freelancer.getAddress(),
+	// ── Step 1: Freelancer proposes a 1 ETH escrow ────────────────────────────
+	console.log("Step 1 - Freelancer proposes a 1 ETH escrow...");
+	const createTx = await tl.connect(freelancer).proposeContract(
+		await client.getAddress(),
 		ethers.keccak256(ethers.toUtf8Bytes("contract-v1")),
 		"ipfs://QmDemo",
 		30 * 24 * 3600, // 30-day estimated duration
@@ -52,11 +52,10 @@ async function main(): Promise<void> {
 		0,
 		0, // no hold-back
 		ethers.ZeroAddress,
-		0n,
-		{ value: ethers.parseEther("1") },
+		ethers.parseEther("1"), // escrow amount the client will lock
 	);
 	const createReceipt = await createTx.wait();
-	if (createReceipt === null) throw new Error("createContract tx not mined");
+	if (createReceipt === null) throw new Error("proposeContract tx not mined");
 
 	const createEvent = createReceipt.logs
 		.map((log): LogDescription | null => {
@@ -66,22 +65,19 @@ async function main(): Promise<void> {
 				return null;
 			}
 		})
-		.find((e): e is LogDescription => e !== null && e.name === "ContractCreated");
-	if (createEvent === undefined) throw new Error("ContractCreated event not found");
+		.find((e): e is LogDescription => e !== null && e.name === "ContractProposed");
+	if (createEvent === undefined) throw new Error("ContractProposed event not found");
 	const contractId = createEvent.args[0] as bigint;
 
 	console.log(`  ✓ Contract ID : ${contractId.toString()}`);
 	console.log(`  ✓ Tx hash     : ${createTx.hash}`);
 	console.log();
 
-	// ── Step 2: Freelancer accepts with ECDSA wallet binding ──────────────────
-	console.log("Step 2 - Freelancer signs & accepts...");
-	const innerHash = ethers.solidityPackedKeccak256(
-		["uint256", "address"],
-		[contractId, await freelancer.getAddress()],
-	);
-	const sig = ethers.Signature.from(await freelancer.signMessage(ethers.getBytes(innerHash)));
-	const acceptTx = await tl.connect(freelancer).acceptContract(contractId, sig.v, sig.r, sig.s);
+	// ── Step 2: Client accepts, funding the escrow ────────────────────────────
+	console.log("Step 2 - Client accepts & funds the escrow...");
+	const acceptTx = await tl
+		.connect(client)
+		.acceptContract(contractId, { value: ethers.parseEther("1") });
 	await acceptTx.wait();
 	console.log(`  ✓ Tx hash     : ${acceptTx.hash}`);
 	console.log();

--- a/scripts/demo/demo-jurors.ts
+++ b/scripts/demo/demo-jurors.ts
@@ -151,9 +151,9 @@ async function main(): Promise<void> {
 	// ── Step 4: Create escrow + dispute ───────────────────────────────────────
 	console.log("Step 3 - Creating contract and opening dispute...");
 	const createTx = await tl
-		.connect(client)
-		.createContract(
-			await freelancer.getAddress(),
+		.connect(freelancer)
+		.proposeContract(
+			await client.getAddress(),
 			ethers.keccak256(ethers.toUtf8Bytes("juror-demo-contract")),
 			"ipfs://QmJurorDemo",
 			30 * 24 * 3600,
@@ -163,11 +163,10 @@ async function main(): Promise<void> {
 			0,
 			0,
 			ethers.ZeroAddress,
-			0n,
-			{ value: ethers.parseEther("1") },
+			ethers.parseEther("1"),
 		);
 	const createReceipt = await createTx.wait();
-	if (createReceipt === null) throw new Error("createContract not mined");
+	if (createReceipt === null) throw new Error("proposeContract not mined");
 	const contractId = createReceipt.logs
 		.map((l): LogDescription | null => {
 			try {
@@ -176,17 +175,14 @@ async function main(): Promise<void> {
 				return null;
 			}
 		})
-		.find((e): e is LogDescription => e !== null && e.name === "ContractCreated")?.args[0] as
+		.find((e): e is LogDescription => e !== null && e.name === "ContractProposed")?.args[0] as
 		| bigint
 		| undefined;
-	if (contractId === undefined) throw new Error("ContractCreated not found");
+	if (contractId === undefined) throw new Error("ContractProposed not found");
 
-	const innerHash = ethers.solidityPackedKeccak256(
-		["uint256", "address"],
-		[contractId, await freelancer.getAddress()],
-	);
-	const sig = ethers.Signature.from(await freelancer.signMessage(ethers.getBytes(innerHash)));
-	await (await tl.connect(freelancer).acceptContract(contractId, sig.v, sig.r, sig.s)).wait();
+	await (
+		await tl.connect(client).acceptContract(contractId, { value: ethers.parseEther("1") })
+	).wait();
 	await (
 		await tl
 			.connect(freelancer)

--- a/scripts/demo/demo-scenarios.ts
+++ b/scripts/demo/demo-scenarios.ts
@@ -187,15 +187,15 @@ async function main(): Promise<void> {
 	console.log("  ok Jurors now eligible to vote");
 	console.log();
 
-	// ── Step 3: Create 1 ETH escrow ──────────────────────────────────────────
-	console.log("Step 3 - Client creates a 1 ETH escrow...");
-	console.log("         The client locks 1 ETH into the smart contract. Neither party can");
-	console.log("         touch these funds until the contract resolves - no trust required,");
+	// ── Step 3: Propose 1 ETH escrow ─────────────────────────────────────────
+	console.log("Step 3 - Freelancer proposes a 1 ETH escrow...");
+	console.log("         The freelancer drafts the terms on-chain. No funds move yet - the");
+	console.log("         client locks the 1 ETH when they accept. No trust required,");
 	console.log("         no middleman, no chargebacks.");
 	const createTx = await tl
-		.connect(client)
-		.createContract(
-			await freelancer.getAddress(),
+		.connect(freelancer)
+		.proposeContract(
+			await client.getAddress(),
 			ethers.keccak256(ethers.toUtf8Bytes(`scenario-${scenarioNum.toString()}-contract`)),
 			"ipfs://QmDemo",
 			30 * 24 * 3600,
@@ -205,11 +205,10 @@ async function main(): Promise<void> {
 			0,
 			0,
 			ethers.ZeroAddress,
-			0n,
-			{ value: ethers.parseEther("1") },
+			ethers.parseEther("1"),
 		);
 	const createReceipt = await createTx.wait();
-	if (createReceipt === null) throw new Error("createContract tx not mined");
+	if (createReceipt === null) throw new Error("proposeContract tx not mined");
 
 	const createEvent = createReceipt.logs
 		.map((log): LogDescription | null => {
@@ -219,23 +218,20 @@ async function main(): Promise<void> {
 				return null;
 			}
 		})
-		.find((e): e is LogDescription => e !== null && e.name === "ContractCreated");
-	if (createEvent === undefined) throw new Error("ContractCreated event not found");
+		.find((e): e is LogDescription => e !== null && e.name === "ContractProposed");
+	if (createEvent === undefined) throw new Error("ContractProposed event not found");
 	const contractId = createEvent.args[0] as bigint;
 	console.log(`  ok Contract ID : ${contractId.toString()}`);
 	console.log();
 
-	// ── Step 4: Freelancer accepts & submits proof ───────────────────────────
-	console.log("Step 4 - Freelancer accepts and submits proof of work...");
-	console.log("         The freelancer cryptographically signs the contract on-chain, then");
-	console.log("         uploads deliverable evidence (IPFS hash). This creates an immutable,");
-	console.log("         timestamped record that neither party can alter later.");
-	const innerHash = ethers.solidityPackedKeccak256(
-		["uint256", "address"],
-		[contractId, await freelancer.getAddress()],
-	);
-	const sig = ethers.Signature.from(await freelancer.signMessage(ethers.getBytes(innerHash)));
-	await (await tl.connect(freelancer).acceptContract(contractId, sig.v, sig.r, sig.s)).wait();
+	// ── Step 4: Client accepts (funds escrow) & freelancer submits proof ──────
+	console.log("Step 4 - Client funds escrow; freelancer submits proof of work...");
+	console.log("         The client locks 1 ETH into the smart contract by accepting. The");
+	console.log("         freelancer then uploads deliverable evidence (IPFS hash), creating an");
+	console.log("         immutable, timestamped record that neither party can alter later.");
+	await (
+		await tl.connect(client).acceptContract(contractId, { value: ethers.parseEther("1") })
+	).wait();
 	await (
 		await tl
 			.connect(freelancer)

--- a/scripts/demo/demo-stablecoin.ts
+++ b/scripts/demo/demo-stablecoin.ts
@@ -62,11 +62,11 @@ async function main(): Promise<void> {
 	console.log();
 
 	// ── Step 3: Gas benchmark - ETH escrow ───────────────────────────────────
-	console.log("Step 3 - Gas benchmark: ETH escrow createContract...");
+	console.log("Step 3 - Gas benchmark: ETH escrow proposeContract...");
 	const ethCreateTx = await tl
-		.connect(client)
-		.createContract(
-			await freelancer.getAddress(),
+		.connect(freelancer)
+		.proposeContract(
+			await client.getAddress(),
 			ethers.keccak256(ethers.toUtf8Bytes("eth-benchmark")),
 			"ipfs://QmEthBenchmark",
 			30 * 24 * 3600,
@@ -76,11 +76,10 @@ async function main(): Promise<void> {
 			0,
 			0,
 			ethers.ZeroAddress,
-			0n,
-			{ value: ethers.parseEther("1") },
+			ethers.parseEther("1"),
 		);
 	const ethReceipt = await ethCreateTx.wait();
-	if (ethReceipt === null) throw new Error("ETH createContract not mined");
+	if (ethReceipt === null) throw new Error("ETH proposeContract not mined");
 	const ethGasUsed = ethReceipt.gasUsed;
 	const ethContractId = ethReceipt.logs
 		.map((l): LogDescription | null => {
@@ -90,23 +89,22 @@ async function main(): Promise<void> {
 				return null;
 			}
 		})
-		.find((e): e is LogDescription => e !== null && e.name === "ContractCreated")?.args[0] as
+		.find((e): e is LogDescription => e !== null && e.name === "ContractProposed")?.args[0] as
 		| bigint
 		| undefined;
-	if (ethContractId === undefined) throw new Error("ContractCreated not found");
+	if (ethContractId === undefined) throw new Error("ContractProposed not found");
 	console.log(`  ok ETH escrow gas : ${ethGasUsed.toString()}`);
 
-	// Cancel the ETH benchmark contract to recover funds
-	await (await tl.connect(client).cancelPending(ethContractId)).wait();
-	console.log(`  ok ETH benchmark contract cancelled (funds returned)`);
+	// Withdraw the ETH benchmark proposal (no funds were held, so nothing to refund)
+	await (await tl.connect(freelancer).cancelProposal(ethContractId)).wait();
+	console.log(`  ok ETH benchmark proposal withdrawn`);
 	console.log();
 
 	// ── Step 4: Gas benchmark - ERC-20 escrow ────────────────────────────────
-	console.log("Step 4 - Gas benchmark: ERC-20 escrow createContract...");
-	await (await token.connect(client).approve(TRUST_LEDGER, ESCROW_AMOUNT)).wait();
+	console.log("Step 4 - Gas benchmark: ERC-20 escrow proposeContract...");
 
-	const erc20CreateTx = await tl.connect(client).createContract(
-		await freelancer.getAddress(),
+	const erc20CreateTx = await tl.connect(freelancer).proposeContract(
+		await client.getAddress(),
 		ethers.keccak256(ethers.toUtf8Bytes("stablecoin-escrow-v1")),
 		"ipfs://QmStablecoinDemo",
 		30 * 24 * 3600,
@@ -116,11 +114,10 @@ async function main(): Promise<void> {
 		0,
 		0,
 		tokenAddress,
-		ESCROW_AMOUNT,
-		// No msg.value - tokens are pulled via transferFrom
+		ESCROW_AMOUNT, // tokens are pulled from the client on acceptContract
 	);
 	const erc20Receipt = await erc20CreateTx.wait();
-	if (erc20Receipt === null) throw new Error("ERC-20 createContract not mined");
+	if (erc20Receipt === null) throw new Error("ERC-20 proposeContract not mined");
 	const erc20GasUsed = erc20Receipt.gasUsed;
 	const contractId = erc20Receipt.logs
 		.map((l): LogDescription | null => {
@@ -130,20 +127,16 @@ async function main(): Promise<void> {
 				return null;
 			}
 		})
-		.find((e): e is LogDescription => e !== null && e.name === "ContractCreated")?.args[0] as
+		.find((e): e is LogDescription => e !== null && e.name === "ContractProposed")?.args[0] as
 		| bigint
 		| undefined;
-	if (contractId === undefined) throw new Error("ContractCreated not found");
-
-	const clientBalanceAfterCreate = await token.balanceOf(client.address);
-	const contractTokenBalance = await token.balanceOf(TRUST_LEDGER);
+	if (contractId === undefined) throw new Error("ContractProposed not found");
 
 	console.log(`  ok ERC-20 escrow gas : ${erc20GasUsed.toString()}`);
 	console.log(`  ok Contract ID       : ${contractId.toString()}`);
 	console.log(
-		`  ok Client balance    : ${ethers.formatUnits(clientBalanceAfterCreate, 18)} MOCK (was 2000, locked 1000)`,
+		`  ok ${ethers.formatUnits(ESCROW_AMOUNT, 18)} MOCK will lock when the client accepts`,
 	);
-	console.log(`  ok Locked in escrow  : ${ethers.formatUnits(contractTokenBalance, 18)} MOCK`);
 	console.log();
 
 	// ── Gas comparison summary ────────────────────────────────────────────────
@@ -157,14 +150,17 @@ async function main(): Promise<void> {
 	console.log(`          price exposure while keeping gas costs the same as ETH escrows.`);
 	console.log();
 
-	// ── Step 5: Freelancer accepts ────────────────────────────────────────────
-	console.log("Step 5 - Freelancer accepts the contract...");
-	const innerHash = ethers.solidityPackedKeccak256(
-		["uint256", "address"],
-		[contractId, await freelancer.getAddress()],
+	// ── Step 5: Client accepts, funding the escrow with tokens ────────────────
+	console.log("Step 5 - Client approves tokens and accepts the contract...");
+	await (await token.connect(client).approve(TRUST_LEDGER, ESCROW_AMOUNT)).wait();
+	await (await tl.connect(client).acceptContract(contractId)).wait();
+
+	const clientBalanceAfterAccept = await token.balanceOf(client.address);
+	const contractTokenBalance = await token.balanceOf(TRUST_LEDGER);
+	console.log(
+		`  ok Client balance    : ${ethers.formatUnits(clientBalanceAfterAccept, 18)} MOCK (locked ${ethers.formatUnits(ESCROW_AMOUNT, 18)})`,
 	);
-	const sig = ethers.Signature.from(await freelancer.signMessage(ethers.getBytes(innerHash)));
-	await (await tl.connect(freelancer).acceptContract(contractId, sig.v, sig.r, sig.s)).wait();
+	console.log(`  ok Locked in escrow  : ${ethers.formatUnits(contractTokenBalance, 18)} MOCK`);
 	console.log("  ok Accepted");
 	console.log();
 

--- a/src/README.md
+++ b/src/README.md
@@ -336,9 +336,9 @@ src/
 | Page                                   | Route                              | Description                                                                                                                             |
 | -------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `page.tsx`                             | `/`                                | Landing page                                                                                                                            |
-| `create/page.tsx`                      | `/create`                          | Create escrow contract - IPFS upload, deadlines, token selection                                                                        |
+| `create/page.tsx`                      | `/create`                          | Propose escrow contract (freelancer) - IPFS upload, deadlines, token selection                                                          |
 | `dashboard/page.tsx`                   | `/dashboard`                       | Lists all contracts for the connected wallet                                                                                            |
-| `freelancer/accept/page.tsx`           | `/freelancer/accept`               | Magic-link accept flow - verifies JWT, renders contract details, triggers ECDSA accept                                                  |
+| `client/accept/page.tsx`               | `/client/accept`                   | Magic-link client flow - verifies token, decrypt-to-view, accept (funds escrow) or reject                                               |
 | `arbitration/[id]/page.tsx`            | `/arbitration/:id`                 | Per-dispute view - commit phase, reveal phase, ruling display                                                                           |
 | `juror/page.tsx`                       | `/juror`                           | Juror portal - stake registration, eligibility, stake management                                                                        |
 | `reputation/page.tsx`                  | `/reputation`                      | Look up cumulative escrow ratings (`ReputationRegistry.averageRating`)                                                                  |
@@ -365,7 +365,7 @@ src/
 | `arweave.ts`    | Uploads files to Arweave for permanent, immutable storage; returns the transaction ID as a URI                                                                                                                           |
 | `encryption.ts` | AES-GCM helpers: `encrypt(data, key)` → ciphertext, `decrypt(ciphertext, key)` → plaintext                                                                                                                               |
 | `ipfs.ts`       | Uploads a `File` or `Blob` to IPFS via Pinata (`uploadToPinata`); returns the IPFS CID used as `contractURI` or `proofOfWorkURI`                                                                                         |
-| `magicLink.ts`  | `signMagicLink(contractId, freelancerAddress)` / `verifyMagicLink(token)` - JWT helpers for the accept flow                                                                                                              |
+| `magicLink.ts`  | `signMagicToken({contractId, clientEmail, clientAddress, …})` / `verifyMagicToken(token)` - HMAC token helpers for the client accept flow                                                                                |
 | `utils.ts`      | `shortenAddress`, `formatEth`, `statusColor` - formatting helpers used across pages                                                                                                                                      |
 | `wagmi.ts`      | Exports `config` (built by the Reown AppKit wagmi adapter), creates the AppKit modal, and resolves contract addresses (`TRUSTLEDGER_ADDRESS`, `REPUTATION_REGISTRY_ADDRESS`, etc.) from env or `deployed-addresses.json` |
 | `walletIds.ts`  | `WALLET_IDS` map of WalletConnect registry IDs and the ordered `FEATURED_WALLET_IDS` list for the AppKit modal (Base, MetaMask, Phantom, Tangem first, then Coinbase, Solflare, Robinhood, Cold, Brave, SoulSwap, …)     |
@@ -481,9 +481,9 @@ writeContract({
 
 | Event                                                      | Contract      | When                            |
 | ---------------------------------------------------------- | ------------- | ------------------------------- |
-| `ContractCreated(id, client, freelancer, amount)`          | TrustLedger   | New escrow created              |
-| `ContractAccepted(id)`                                     | TrustLedger   | Freelancer accepted             |
-| `ContractRejected(id)`                                     | TrustLedger   | Freelancer rejected             |
+| `ContractProposed(id, client, freelancer, amount)`         | TrustLedger   | Freelancer proposed a contract  |
+| `ContractAccepted(id)`                                     | TrustLedger   | Client accepted & funded escrow |
+| `ContractRejected(id)`                                     | TrustLedger   | Client rejected the proposal    |
 | `ProofSubmitted(id, hash, uri)`                            | TrustLedger   | Proof of work uploaded          |
 | `WorkApproved(id)`                                         | TrustLedger   | Client approved                 |
 | `WorkDisputed(id, arbitrationId)`                          | TrustLedger   | Dispute opened                  |

--- a/src/app/api/magic-link/send/route.ts
+++ b/src/app/api/magic-link/send/route.ts
@@ -14,33 +14,33 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 	if (apiKey === undefined || apiKey === "")
 		return NextResponse.json({ error: "RESEND_API_KEY not set" }, { status: 500 });
 
-	let body: { contractId?: unknown; freelancerEmail?: unknown; freelancerAddress?: unknown };
+	let body: { contractId?: unknown; clientEmail?: unknown; clientAddress?: unknown };
 	try {
 		body = (await req.json()) as typeof body;
 	} catch {
 		return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
 	}
 
-	const { contractId, freelancerEmail, freelancerAddress } = body;
+	const { contractId, clientEmail, clientAddress } = body;
 	if (typeof contractId !== "string" || contractId === "")
 		return NextResponse.json({ error: "contractId required" }, { status: 400 });
-	if (typeof freelancerEmail !== "string" || !freelancerEmail.includes("@"))
-		return NextResponse.json({ error: "valid freelancerEmail required" }, { status: 400 });
-	if (typeof freelancerAddress !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(freelancerAddress))
-		return NextResponse.json({ error: "valid freelancerAddress required" }, { status: 400 });
+	if (typeof clientEmail !== "string" || !clientEmail.includes("@"))
+		return NextResponse.json({ error: "valid clientEmail required" }, { status: 400 });
+	if (typeof clientAddress !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(clientAddress))
+		return NextResponse.json({ error: "valid clientAddress required" }, { status: 400 });
 
 	const nonce = Buffer.from(crypto.getRandomValues(new Uint8Array(16))).toString("hex");
 	const exp = Math.floor(Date.now() / 1000) + EXPIRY_SECONDS;
 
 	const token = await signMagicToken(
-		{ contractId, freelancerEmail, freelancerAddress, nonce, exp },
+		{ contractId, clientEmail, clientAddress, nonce, exp },
 		secret,
 	);
 
-	const link = `${appUrl}/freelancer/accept?token=${encodeURIComponent(token)}`;
+	const link = `${appUrl}/client/accept?token=${encodeURIComponent(token)}`;
 
 	const result = await sendEmail({
-		to: freelancerEmail,
+		to: clientEmail,
 		subject: `You have a new contract to review - TrustLedger #${contractId}`,
 		html: buildEmail(link, contractId),
 	});
@@ -56,11 +56,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 // single-use, wallet-bound caveat is the only copy specific to this flow.
 function buildEmail(link: string, contractId: string): string {
 	return emailShell(
-		"New Escrow Contract",
-		`Contract <strong>#${contractId}</strong> is awaiting your review and acceptance.<br /><br />
-		 Click the button below to review the contract details and connect your wallet to accept.
-		 This link expires in 72 hours and is single-use.`,
-		{ label: "Review &amp; Accept Contract", href: link },
+		"New Escrow Contract Proposal",
+		`A freelancer has proposed contract <strong>#${contractId}</strong> and it is awaiting your review.<br /><br />
+		 Click the button below to review the terms, securely view the contract document, and connect
+		 your wallet to accept (locking the escrow) or reject. This link expires in 72 hours.`,
+		{ label: "Review Proposal", href: link },
 		"If you were not expecting this email, you can ignore it. Do not share this link — it is tied to your wallet address.",
 	);
 }

--- a/src/app/client/accept/page.tsx
+++ b/src/app/client/accept/page.tsx
@@ -8,15 +8,17 @@ import {
 	useReadContract,
 	useWriteContract,
 	useWaitForTransactionReceipt,
-	useSignMessage,
 } from "wagmi";
 import { ConnectButton } from "@/components/ConnectButton";
-import { keccak256, encodePacked, parseSignature } from "viem";
+import { DecryptDocumentForm } from "@/components/DecryptDocumentForm";
 import { TRUSTLEDGER_ABI, STATUS_LABELS } from "@/lib/abi";
 import { TRUSTLEDGER_ADDRESS, getExplorerTxUrl } from "@/lib/wagmi";
 import { formatEth, resolveDocUrl } from "@/lib/utils";
 import type { MagicLinkPayload } from "@/lib/magicLink";
 
+// The client lands here from the magic-link email. They review the freelancer's
+// proposal, securely view the (optionally encrypted) IPFS contract document, then
+// either accept — funding the escrow in the same transaction — or reject it.
 function AcceptPageInner(): React.JSX.Element {
 	const searchParams = useSearchParams();
 	const token = searchParams.get("token") ?? "";
@@ -26,6 +28,7 @@ function AcceptPageInner(): React.JSX.Element {
 		token === "" ? "No token provided." : null,
 	);
 	const [tokenLoading, setTokenLoading] = useState(token !== "");
+	const [decryptOpen, setDecryptOpen] = useState(false);
 
 	useEffect(() => {
 		if (token === "") return;
@@ -62,42 +65,40 @@ function AcceptPageInner(): React.JSX.Element {
 	});
 
 	const {
-		signMessage,
-		data: signature,
-		isPending: isSigning,
-		error: signError,
-	} = useSignMessage();
-	const {
 		writeContract,
 		data: txHash,
 		isPending: isSending,
 		error: writeError,
 	} = useWriteContract();
 	const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
+	// Tracks which action the in-flight transaction represents so the success screen
+	// can show the right copy.
+	const [action, setAction] = useState<"accept" | "reject" | null>(null);
 
 	const explorerTxUrl = txHash !== undefined ? getExplorerTxUrl(chainId, txHash) : null;
 
-	function handleSign(): void {
-		if (payload === null) return;
-		const message = keccak256(
-			encodePacked(
-				["uint256", "address"],
-				[BigInt(payload.contractId), payload.freelancerAddress as `0x${string}`],
-			),
-		);
-		signMessage({ message: { raw: message } });
-	}
-
-	useEffect(() => {
-		if (signature === undefined || payload === null) return;
-		const { v, r, s } = parseSignature(signature);
+	function handleAccept(): void {
+		if (payload === null || contract === undefined) return;
+		setAction("accept");
 		writeContract({
 			address: TRUSTLEDGER_ADDRESS,
 			abi: TRUSTLEDGER_ABI,
 			functionName: "acceptContract",
-			args: [BigInt(payload.contractId), Number(v), r, s],
+			args: [BigInt(payload.contractId)],
+			value: contract.amount, // fund the escrow with exactly the proposed amount
 		});
-	}, [signature, payload, writeContract]);
+	}
+
+	function handleReject(): void {
+		if (payload === null) return;
+		setAction("reject");
+		writeContract({
+			address: TRUSTLEDGER_ADDRESS,
+			abi: TRUSTLEDGER_ABI,
+			functionName: "rejectContract",
+			args: [BigInt(payload.contractId)],
+		});
+	}
 
 	// - Loading states -
 	if (tokenLoading)
@@ -126,9 +127,9 @@ function AcceptPageInner(): React.JSX.Element {
 				<p className="text-gray-500 dark:text-gray-400 text-sm mb-4">
 					Connect the wallet at{" "}
 					<span className="font-mono text-indigo-600 dark:text-indigo-400">
-						{payload?.freelancerAddress}
+						{payload?.clientAddress}
 					</span>{" "}
-					to accept contract #{payload?.contractId}.
+					to review contract #{payload?.contractId}.
 				</p>
 				<ConnectButton />
 			</PageShell>
@@ -136,7 +137,7 @@ function AcceptPageInner(): React.JSX.Element {
 	}
 
 	// Wallet address mismatch
-	const expectedAddress = payload?.freelancerAddress.toLowerCase();
+	const expectedAddress = payload?.clientAddress.toLowerCase();
 	if (address?.toLowerCase() !== expectedAddress) {
 		return (
 			<PageShell>
@@ -147,7 +148,7 @@ function AcceptPageInner(): React.JSX.Element {
 					<p className="text-gray-500 dark:text-gray-400 text-sm">
 						This link is for{" "}
 						<span className="font-mono text-yellow-600 dark:text-yellow-300">
-							{payload?.freelancerAddress}
+							{payload?.clientAddress}
 						</span>
 						. Please switch to that account.
 					</p>
@@ -170,11 +171,14 @@ function AcceptPageInner(): React.JSX.Element {
 	const statusLabel = STATUS_LABELS[contract.status] ?? "Unknown";
 
 	if (isSuccess) {
+		const accepted = action === "accept";
 		return (
 			<PageShell>
-				<div className="w-16 h-16 rounded-full bg-green-500/10 flex items-center justify-center mx-auto mb-4">
+				<div
+					className={`w-16 h-16 rounded-full ${accepted ? "bg-green-500/10" : "bg-gray-500/10"} flex items-center justify-center mx-auto mb-4`}
+				>
 					<svg
-						className="w-8 h-8 text-green-500 dark:text-green-400"
+						className={`w-8 h-8 ${accepted ? "text-green-500 dark:text-green-400" : "text-gray-500 dark:text-gray-400"}`}
 						fill="none"
 						viewBox="0 0 24 24"
 						stroke="currentColor"
@@ -183,13 +187,17 @@ function AcceptPageInner(): React.JSX.Element {
 							strokeLinecap="round"
 							strokeLinejoin="round"
 							strokeWidth={2}
-							d="M5 13l4 4L19 7"
+							d={accepted ? "M5 13l4 4L19 7" : "M6 18L18 6M6 6l12 12"}
 						/>
 					</svg>
 				</div>
-				<h2 className="text-2xl font-bold text-center mb-2">Contract Accepted!</h2>
+				<h2 className="text-2xl font-bold text-center mb-2">
+					{accepted ? "Contract Accepted!" : "Proposal Rejected"}
+				</h2>
 				<p className="text-gray-500 dark:text-gray-400 text-sm text-center mb-4">
-					The project deadline timer has started.
+					{accepted
+						? "The escrow is funded and the project deadline timer has started."
+						: "The proposal has been declined. No funds were transferred."}
 				</p>
 				{txHash !== undefined && explorerTxUrl !== null && (
 					<a
@@ -205,14 +213,16 @@ function AcceptPageInner(): React.JSX.Element {
 		);
 	}
 
-	const canAccept = contract.status === 0; // PENDING
+	const canRespond = contract.status === 0; // PENDING
 	const docUrl = resolveDocUrl(contract.contractURI);
+	const busy = isSending || isConfirming;
 
 	return (
 		<PageShell>
 			<h1 className="text-2xl font-bold mb-1">Contract #{payload?.contractId}</h1>
 			<p className="text-gray-500 dark:text-gray-400 text-sm mb-6">
-				Review the terms below before accepting.
+				Review the terms and document below. Accepting locks {formatEth(contract.amount)} in
+				escrow.
 			</p>
 
 			<div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/5 p-5 flex flex-col gap-3 text-sm mb-6">
@@ -224,7 +234,7 @@ function AcceptPageInner(): React.JSX.Element {
 					label="Deadline"
 					value={
 						contract.projectDeadline > 0n
-							? new Date(Number(contract.projectDeadline) * 1000).toLocaleDateString()
+							? `~${String(Math.round(Number(contract.projectDeadline) / 86400))} days after acceptance`
 							: "Set on acceptance"
 					}
 				/>
@@ -235,46 +245,76 @@ function AcceptPageInner(): React.JSX.Element {
 					<Row
 						label="Document"
 						value={
-							<a
-								href={docUrl}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300 underline underline-offset-2 truncate"
-							>
-								{contract.contractURI}
-							</a>
+							<span className="flex items-center justify-end gap-2">
+								<a
+									href={docUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300 underline underline-offset-2"
+								>
+									View
+								</a>
+								<span className="text-gray-300 dark:text-gray-600 text-xs">·</span>
+								<button
+									type="button"
+									onClick={() => {
+										setDecryptOpen((o) => !o);
+									}}
+									className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-500 dark:hover:text-indigo-300 underline underline-offset-2"
+								>
+									{decryptOpen ? "Hide decrypt" : "Decrypt"}
+								</button>
+							</span>
 						}
 					/>
 				)}
 			</div>
 
-			{!canAccept && (
-				<div className="rounded-xl bg-yellow-500/10 border border-yellow-500/20 px-4 py-3 text-sm text-yellow-600 dark:text-yellow-400 mb-4">
-					Contract is not in PENDING state (current: {statusLabel}). It may already be
-					accepted or cancelled.
+			{/* Decrypt-and-view panel for AES-256-GCM encrypted documents. */}
+			{docUrl !== undefined && decryptOpen && (
+				<div className="mb-6">
+					<DecryptDocumentForm
+						gatewayUrl={docUrl}
+						onClose={() => {
+							setDecryptOpen(false);
+						}}
+					/>
 				</div>
 			)}
 
-			{(signError ?? writeError) !== null && (
+			{!canRespond && (
+				<div className="rounded-xl bg-yellow-500/10 border border-yellow-500/20 px-4 py-3 text-sm text-yellow-600 dark:text-yellow-400 mb-4">
+					Contract is not awaiting acceptance (current: {statusLabel}). It may already be
+					accepted, rejected, or withdrawn.
+				</div>
+			)}
+
+			{writeError !== null && (
 				<p className="text-red-500 dark:text-red-400 text-sm rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-3 mb-4">
-					{((signError ?? writeError) as { shortMessage?: string } | null)
-						?.shortMessage ?? (signError ?? writeError)?.message}
+					{(writeError as { shortMessage?: string }).shortMessage ?? writeError.message}
 				</p>
 			)}
 
-			<button
-				onClick={handleSign}
-				disabled={!canAccept || isSigning || isSending || isConfirming}
-				className="w-full px-6 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold transition-colors"
-			>
-				{isSigning
-					? "Sign in wallet…"
-					: isSending
-						? "Waiting for wallet…"
-						: isConfirming
+			<div className="flex gap-3">
+				<button
+					onClick={handleAccept}
+					disabled={!canRespond || busy}
+					className="flex-1 px-6 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-semibold transition-colors"
+				>
+					{busy && action === "accept"
+						? isConfirming
 							? "Confirming on-chain…"
-							: "Accept Contract"}
-			</button>
+							: "Waiting for wallet…"
+						: `Accept & Fund (${formatEth(contract.amount)})`}
+				</button>
+				<button
+					onClick={handleReject}
+					disabled={!canRespond || busy}
+					className="px-6 py-3 rounded-xl border border-gray-300 dark:border-white/15 hover:bg-gray-100 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed text-gray-700 dark:text-gray-200 font-semibold transition-colors"
+				>
+					{busy && action === "reject" ? "Rejecting…" : "Reject"}
+				</button>
+			</div>
 		</PageShell>
 	);
 }

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -40,8 +40,8 @@ export default function CreatePage(): React.JSX.Element {
 	} = useWaitForTransactionReceipt({ hash: txHash });
 
 	const [form, setForm] = useState({
-		freelancer: "",
-		freelancerEmail: "",
+		client: "",
+		clientEmail: "",
 		amountEth: "",
 		contractURI: "",
 		estimatedDurationDays: "30",
@@ -93,8 +93,8 @@ export default function CreatePage(): React.JSX.Element {
 
 	const fieldErrors = useMemo(
 		() => ({
-			freelancer: validateEthAddress(form.freelancer),
-			freelancerEmail: validateEmail(form.freelancerEmail),
+			client: validateEthAddress(form.client),
+			clientEmail: validateEmail(form.clientEmail),
 			amountEth: validateEthAmount(form.amountEth),
 			contractURI: docMode === "manual" ? validateContractUri(form.contractURI) : undefined,
 			estimatedDurationDays: validateNumberInRange(form.estimatedDurationDays, 1, 3650, {
@@ -134,7 +134,7 @@ export default function CreatePage(): React.JSX.Element {
 	// too high" symptom caused by gas estimation failing on a reverting transaction.
 	const txArgs = useMemo(() => {
 		if (
-			!/^0x[0-9a-fA-F]{40}$/.test(form.freelancer) ||
+			!/^0x[0-9a-fA-F]{40}$/.test(form.client) ||
 			form.amountEth === "" ||
 			Number(form.amountEth) <= 0 ||
 			Number(form.arbitrationFeePct) <= 0
@@ -143,12 +143,14 @@ export default function CreatePage(): React.JSX.Element {
 		}
 		const trimmedURI = form.contractURI.trim();
 		const contractURI = trimmedURI !== "" ? trimmedURI : "ipfs://";
+		// Freelancer proposes unfunded terms; the escrow amount is a parameter the client will
+		// lock on acceptance, so no ETH (value) is sent with this transaction.
 		return {
 			address: TRUSTLEDGER_ADDRESS,
 			abi: TRUSTLEDGER_ABI,
-			functionName: "createContract" as const,
+			functionName: "proposeContract" as const,
 			args: [
-				form.freelancer as `0x${string}`,
+				form.client as `0x${string}`,
 				fileHash ?? keccak256(toBytes(contractURI)),
 				contractURI,
 				daysToSeconds(Number(form.estimatedDurationDays)),
@@ -158,9 +160,8 @@ export default function CreatePage(): React.JSX.Element {
 				form.holdBack === "none" ? 0 : Number(form.holdBack) * 100,
 				form.holdBack === "none" ? 0n : BigInt(Number(form.warrantyPeriodDays) * 86400),
 				"0x0000000000000000000000000000000000000000",
-				0n,
+				parseEther(form.amountEth),
 			] as const,
-			value: parseEther(form.amountEth),
 		};
 	}, [form, fileHash]);
 
@@ -179,11 +180,11 @@ export default function CreatePage(): React.JSX.Element {
 	}
 
 	useEffect(() => {
-		if (!isSuccess || form.freelancerEmail === "") return;
+		if (!isSuccess || form.clientEmail === "") return;
 
 		const logs = parseEventLogs({
 			abi: TRUSTLEDGER_ABI,
-			eventName: "ContractCreated",
+			eventName: "ContractProposed",
 			logs: receipt.logs,
 		});
 		const contractId = logs[0]?.args.id;
@@ -194,8 +195,8 @@ export default function CreatePage(): React.JSX.Element {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({
 				contractId: contractId.toString(),
-				freelancerEmail: form.freelancerEmail,
-				freelancerAddress: form.freelancer,
+				clientEmail: form.clientEmail,
+				clientAddress: form.client,
 			}),
 		})
 			.then((r) => {
@@ -204,7 +205,7 @@ export default function CreatePage(): React.JSX.Element {
 			.catch(() => {
 				setMagicLinkStatus("error");
 			});
-	}, [isSuccess, receipt, form.freelancerEmail, form.freelancer]);
+	}, [isSuccess, receipt, form.clientEmail, form.client]);
 
 	async function handleUploadToIPFS(): Promise<void> {
 		if (selectedFile === null) return;
@@ -284,7 +285,7 @@ export default function CreatePage(): React.JSX.Element {
 		return (
 			<div className="flex flex-col items-center justify-center gap-6 py-32">
 				<p className="text-gray-500 dark:text-gray-400 text-lg">
-					Connect your wallet to create a contract.
+					Connect your wallet to propose a contract.
 				</p>
 				<ConnectButton />
 			</div>
@@ -309,7 +310,7 @@ export default function CreatePage(): React.JSX.Element {
 						/>
 					</svg>
 				</div>
-				<h2 className="text-2xl font-bold">Contract Created!</h2>
+				<h2 className="text-2xl font-bold">Contract Proposed!</h2>
 				<p className="text-gray-500 dark:text-gray-400 text-sm">
 					Transaction confirmed in block {receipt.blockNumber.toString()}.
 				</p>
@@ -321,7 +322,7 @@ export default function CreatePage(): React.JSX.Element {
 				>
 					View on explorer
 				</a>
-				{form.freelancerEmail !== "" && (
+				{form.clientEmail !== "" && (
 					<p className="text-sm">
 						{magicLinkStatus === "sending" && (
 							<span className="text-gray-500 dark:text-gray-400">
@@ -330,7 +331,7 @@ export default function CreatePage(): React.JSX.Element {
 						)}
 						{magicLinkStatus === "sent" && (
 							<span className="text-green-500 dark:text-green-400">
-								Magic link sent to {form.freelancerEmail}
+								Magic link sent to {form.clientEmail}
 							</span>
 						)}
 						{magicLinkStatus === "error" && (
@@ -355,9 +356,10 @@ export default function CreatePage(): React.JSX.Element {
 	return (
 		<div className="max-w-2xl mx-auto px-6 py-12">
 			<div className="mb-8">
-				<h1 className="text-3xl font-bold">New Escrow Contract</h1>
+				<h1 className="text-3xl font-bold">Propose Escrow Contract</h1>
 				<p className="text-gray-500 dark:text-gray-400 mt-2 text-sm">
-					ETH will be held in escrow until the freelancer delivers and you approve - or a
+					You propose the terms; the client reviews and locks the ETH in escrow on
+					acceptance. Funds are released once you deliver and the client approves - or a
 					dispute is resolved.
 				</p>
 			</div>
@@ -370,48 +372,48 @@ export default function CreatePage(): React.JSX.Element {
 					</h2>
 
 					<Field
-						label="Freelancer Address"
-						hint="The wallet that will receive payment on completion."
-						error={showError("freelancer")}
+						label="Client Address"
+						hint="The wallet that will review, fund, and approve this contract."
+						error={showError("client")}
 					>
 						<Input
 							type="text"
 							placeholder="0x..."
-							value={form.freelancer}
+							value={form.client}
 							onChange={(e) => {
-								set("freelancer", e.target.value);
+								set("client", e.target.value);
 							}}
 							onBlur={() => {
-								markTouched("freelancer");
+								markTouched("client");
 							}}
-							error={showError("freelancer") !== undefined}
+							error={showError("client") !== undefined}
 							required
 							pattern="^0x[0-9a-fA-F]{40}$"
 						/>
 					</Field>
 
 					<Field
-						label="Freelancer Email"
-						hint="A signed magic link will be sent here so the freelancer can accept via the web."
-						error={showError("freelancerEmail")}
+						label="Client Email"
+						hint="A signed magic link will be sent here so the client can review and accept via the web."
+						error={showError("clientEmail")}
 					>
 						<Input
 							type="email"
-							placeholder="freelancer@example.com"
-							value={form.freelancerEmail}
+							placeholder="client@example.com"
+							value={form.clientEmail}
 							onChange={(e) => {
-								set("freelancerEmail", e.target.value);
+								set("clientEmail", e.target.value);
 							}}
 							onBlur={() => {
-								markTouched("freelancerEmail");
+								markTouched("clientEmail");
 							}}
-							error={showError("freelancerEmail") !== undefined}
+							error={showError("clientEmail") !== undefined}
 						/>
 					</Field>
 
 					<Field
 						label="Escrow Amount (ETH)"
-						hint="Total ETH to lock in escrow."
+						hint="Total ETH the client will lock in escrow on acceptance."
 						error={showError("amountEth")}
 					>
 						<Input
@@ -860,7 +862,7 @@ export default function CreatePage(): React.JSX.Element {
 						? "Waiting for wallet…"
 						: isConfirming
 							? "Confirming on-chain…"
-							: "Create Escrow Contract"}
+							: "Propose Escrow Contract"}
 				</button>
 			</form>
 		</div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,12 +3,12 @@
 import { useState } from "react";
 import { useAccount, useReadContract, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
 import { ConnectButton } from "@/components/ConnectButton";
+import { DecryptDocumentForm } from "@/components/DecryptDocumentForm";
 import { formatEther, keccak256, toBytes } from "viem";
 import { TRUSTLEDGER_ABI, STATUS_LABELS } from "@/lib/abi";
 import { REPUTATION_REGISTRY_ADDRESS, TRUSTLEDGER_ADDRESS } from "@/lib/wagmi";
 import { formatAddress, formatDeadline, resolveDocUrl, STATUS_COLORS } from "@/lib/utils";
-import { validateRequired, validateRequiredUri, validateScore } from "@/lib/validation";
-import { decryptFile } from "@/lib/encryption";
+import { validateRequiredUri, validateScore } from "@/lib/validation";
 import type { Contract } from "@/types";
 import Link from "next/link";
 
@@ -31,11 +31,14 @@ function ActionButton({
 	contractId,
 	functionName,
 	disabled,
+	value,
 }: {
 	label: string;
 	contractId: bigint;
 	functionName: string;
 	disabled?: boolean;
+	// Optional ETH to send with the call (in wei). Used by acceptContract to fund the escrow.
+	value?: bigint;
 }): React.JSX.Element {
 	const { writeContract, data: txHash, isPending } = useWriteContract();
 	const { isLoading: isConfirming } = useWaitForTransactionReceipt({ hash: txHash });
@@ -49,6 +52,7 @@ function ActionButton({
 					abi: TRUSTLEDGER_ABI,
 					functionName: functionName as never,
 					args: [contractId],
+					...(value !== undefined ? { value } : {}),
 				});
 			}}
 			className="px-3 py-1.5 text-xs rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white font-medium transition-colors"
@@ -221,209 +225,6 @@ function SubmitWorkForm({ contractId }: { contractId: bigint }): React.JSX.Eleme
 	);
 }
 
-type DecryptMode = "fetch" | "paste";
-type DecryptStatus = "idle" | "working" | "done" | "error";
-
-/// Full-width decrypt panel for AES-256-GCM encrypted IPFS documents.
-/// Rendered by ContractCard below the info grid when the user toggles decrypt open.
-/// Supports fetching the bundle from a gateway URL or accepting a pasted JSON bundle.
-function DecryptDocumentForm({
-	gatewayUrl,
-	onClose,
-}: {
-	gatewayUrl: string;
-	onClose: () => void;
-}): React.JSX.Element {
-	const [mode, setMode] = useState<DecryptMode>("fetch");
-	const [pastedBundle, setPastedBundle] = useState("");
-	const [passphrase, setPassphrase] = useState("");
-	const [filename, setFilename] = useState("decrypted-document");
-	const [status, setStatus] = useState<DecryptStatus>("idle");
-	const [errorMsg, setErrorMsg] = useState<string | null>(null);
-	const [passphraseTouched, setPassphraseTouched] = useState(false);
-	const [bundleTouched, setBundleTouched] = useState(false);
-
-	const passphraseError = validateRequired(passphrase, "Passphrase");
-	const bundleError =
-		mode === "paste" ? validateRequired(pastedBundle, "Encrypted bundle") : undefined;
-
-	async function handleDecrypt(): Promise<void> {
-		setStatus("working");
-		setErrorMsg(null);
-		try {
-			let buffer: ArrayBuffer;
-			if (mode === "fetch") {
-				const res = await fetch(gatewayUrl);
-				if (!res.ok)
-					throw new Error(`Gateway returned ${String(res.status)} ${res.statusText}`);
-				buffer = await res.arrayBuffer();
-			} else {
-				buffer = new TextEncoder().encode(pastedBundle.trim()).buffer;
-			}
-			const decrypted = await decryptFile(buffer, passphrase);
-			// Trigger a browser download by creating a temporary <a> element, clicking it,
-			// and immediately revoking the object URL to free memory.
-			const url = URL.createObjectURL(new Blob([decrypted]));
-			const a = document.createElement("a");
-			a.href = url;
-			a.download = filename.trim() !== "" ? filename.trim() : "decrypted-document";
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
-			URL.revokeObjectURL(url);
-			setStatus("done");
-		} catch (err) {
-			// AES-GCM throws OperationError when the passphrase is wrong or ciphertext is tampered.
-			const friendly =
-				err instanceof DOMException && err.name === "OperationError"
-					? "Decryption failed — wrong passphrase or corrupted bundle."
-					: err instanceof Error
-						? err.message
-						: String(err);
-			setErrorMsg(friendly);
-			setStatus("error");
-		}
-	}
-
-	return (
-		<div className="flex flex-col gap-3 rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-4">
-			<div className="flex items-center justify-between">
-				<span className="text-xs font-medium text-gray-700 dark:text-gray-200">
-					Decrypt AES-256-GCM document
-				</span>
-				<button
-					type="button"
-					onClick={onClose}
-					className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-				>
-					✕
-				</button>
-			</div>
-
-			{/* Source mode toggle: "fetch" loads from the IPFS gateway URI; "paste" accepts a copied JSON bundle */}
-			<div className="flex gap-1 rounded-lg bg-gray-100 dark:bg-white/5 p-1 self-start">
-				{(["fetch", "paste"] as DecryptMode[]).map((m) => (
-					<button
-						key={m}
-						type="button"
-						onClick={() => {
-							setMode(m);
-						}}
-						className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
-							mode === m
-								? "bg-indigo-600 text-white"
-								: "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
-						}`}
-					>
-						{m === "fetch" ? "Fetch from URI" : "Paste bundle"}
-					</button>
-				))}
-			</div>
-
-			{mode === "fetch" ? (
-				<p className="text-xs text-gray-500 break-all">
-					Will fetch:{" "}
-					<span className="font-mono text-gray-600 dark:text-gray-400">{gatewayUrl}</span>
-				</p>
-			) : (
-				<div className="flex flex-col gap-1">
-					<textarea
-						rows={4}
-						placeholder={'{"v":1,"alg":"AES-256-GCM",…}'}
-						value={pastedBundle}
-						onChange={(e) => {
-							setPastedBundle(e.target.value);
-						}}
-						onBlur={() => {
-							setBundleTouched(true);
-						}}
-						aria-invalid={bundleTouched && bundleError !== undefined}
-						className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-xs text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 font-mono focus:outline-none focus:ring-2 resize-none ${
-							bundleTouched && bundleError !== undefined
-								? "border-red-500 dark:border-red-500 focus:ring-red-500"
-								: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
-						}`}
-					/>
-					{bundleTouched && bundleError !== undefined && (
-						<p className="text-xs text-red-500 dark:text-red-400">{bundleError}</p>
-					)}
-				</div>
-			)}
-
-			<div className="flex flex-col gap-1">
-				<input
-					type="password"
-					placeholder="Passphrase"
-					value={passphrase}
-					onChange={(e) => {
-						setPassphrase(e.target.value);
-					}}
-					onBlur={() => {
-						setPassphraseTouched(true);
-					}}
-					aria-invalid={passphraseTouched && passphraseError !== undefined}
-					className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 ${
-						passphraseTouched && passphraseError !== undefined
-							? "border-red-500 dark:border-red-500 focus:ring-red-500"
-							: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
-					}`}
-				/>
-				{passphraseTouched && passphraseError !== undefined && (
-					<p className="text-xs text-red-500 dark:text-red-400">{passphraseError}</p>
-				)}
-			</div>
-
-			<input
-				type="text"
-				placeholder="Output filename (e.g. contract.pdf)"
-				value={filename}
-				onChange={(e) => {
-					setFilename(e.target.value);
-				}}
-				className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-			/>
-
-			{status === "done" ? (
-				<p className="text-xs text-green-500 dark:text-green-400">
-					✓ File downloaded.{" "}
-					<button
-						type="button"
-						onClick={() => {
-							setStatus("idle");
-							setErrorMsg(null);
-							setPassphrase("");
-						}}
-						className="underline text-gray-500 hover:text-gray-900 dark:hover:text-white"
-					>
-						Decrypt another
-					</button>
-				</p>
-			) : (
-				<button
-					type="button"
-					onClick={() => {
-						void handleDecrypt();
-					}}
-					disabled={
-						status === "working" ||
-						passphrase === "" ||
-						(mode === "paste" && pastedBundle.trim() === "")
-					}
-					className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors"
-				>
-					{status === "working" ? "Decrypting…" : "Decrypt & Download"}
-				</button>
-			)}
-
-			{status === "error" && errorMsg !== null && (
-				<p className="text-xs text-red-500 dark:text-red-400 rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2">
-					{errorMsg}
-				</p>
-			)}
-		</div>
-	);
-}
-
 // Renders one escrow contract with its current state and the actions available to the
 // connected wallet. Which buttons appear depends on:
 //   - the contract's status (0-6)
@@ -538,13 +339,14 @@ function ContractCard({
 
 			{/* Actions — each block is gated by role (isClient/isFreelancer) and status number */}
 			<div className="flex flex-wrap gap-2">
-				{/* status 0 = PENDING: freelancer can accept or reject */}
-				{isFreelancer && status === 0 && (
+				{/* status 0 = PENDING: client accepts (funding the escrow) or rejects the proposal */}
+				{isClient && status === 0 && (
 					<>
 						<ActionButton
-							label="Accept"
+							label="Accept & Fund"
 							contractId={id}
 							functionName="acceptContract"
+							value={contract.amount}
 						/>
 						<ActionButton
 							label="Reject"
@@ -552,6 +354,14 @@ function ContractCard({
 							functionName="rejectContract"
 						/>
 					</>
+				)}
+				{/* status 0 = PENDING: freelancer can withdraw their own proposal */}
+				{isFreelancer && status === 0 && (
+					<ActionButton
+						label="Withdraw Proposal"
+						contractId={id}
+						functionName="cancelProposal"
+					/>
 				)}
 				{/* status 2 = SUBMITTED: client reviews the proof-of-work */}
 				{isClient && status === 2 && (

--- a/src/components/DecryptDocumentForm.tsx
+++ b/src/components/DecryptDocumentForm.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { validateRequired } from "@/lib/validation";
+import { decryptFile } from "@/lib/encryption";
+
+type DecryptMode = "fetch" | "paste";
+type DecryptStatus = "idle" | "working" | "done" | "error";
+
+/// Full-width decrypt panel for AES-256-GCM encrypted IPFS documents.
+/// Rendered by ContractCard below the info grid when the user toggles decrypt open.
+/// Supports fetching the bundle from a gateway URL or accepting a pasted JSON bundle.
+export function DecryptDocumentForm({
+	gatewayUrl,
+	onClose,
+}: {
+	gatewayUrl: string;
+	onClose: () => void;
+}): React.JSX.Element {
+	const [mode, setMode] = useState<DecryptMode>("fetch");
+	const [pastedBundle, setPastedBundle] = useState("");
+	const [passphrase, setPassphrase] = useState("");
+	const [filename, setFilename] = useState("decrypted-document");
+	const [status, setStatus] = useState<DecryptStatus>("idle");
+	const [errorMsg, setErrorMsg] = useState<string | null>(null);
+	const [passphraseTouched, setPassphraseTouched] = useState(false);
+	const [bundleTouched, setBundleTouched] = useState(false);
+
+	const passphraseError = validateRequired(passphrase, "Passphrase");
+	const bundleError =
+		mode === "paste" ? validateRequired(pastedBundle, "Encrypted bundle") : undefined;
+
+	async function handleDecrypt(): Promise<void> {
+		setStatus("working");
+		setErrorMsg(null);
+		try {
+			let buffer: ArrayBuffer;
+			if (mode === "fetch") {
+				const res = await fetch(gatewayUrl);
+				if (!res.ok)
+					throw new Error(`Gateway returned ${String(res.status)} ${res.statusText}`);
+				buffer = await res.arrayBuffer();
+			} else {
+				buffer = new TextEncoder().encode(pastedBundle.trim()).buffer;
+			}
+			const decrypted = await decryptFile(buffer, passphrase);
+			// Trigger a browser download by creating a temporary <a> element, clicking it,
+			// and immediately revoking the object URL to free memory.
+			const url = URL.createObjectURL(new Blob([decrypted]));
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = filename.trim() !== "" ? filename.trim() : "decrypted-document";
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			URL.revokeObjectURL(url);
+			setStatus("done");
+		} catch (err) {
+			// AES-GCM throws OperationError when the passphrase is wrong or ciphertext is tampered.
+			const friendly =
+				err instanceof DOMException && err.name === "OperationError"
+					? "Decryption failed — wrong passphrase or corrupted bundle."
+					: err instanceof Error
+						? err.message
+						: String(err);
+			setErrorMsg(friendly);
+			setStatus("error");
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-3 rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-4">
+			<div className="flex items-center justify-between">
+				<span className="text-xs font-medium text-gray-700 dark:text-gray-200">
+					Decrypt AES-256-GCM document
+				</span>
+				<button
+					type="button"
+					onClick={onClose}
+					className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+				>
+					✕
+				</button>
+			</div>
+
+			{/* Source mode toggle: "fetch" loads from the IPFS gateway URI; "paste" accepts a copied JSON bundle */}
+			<div className="flex gap-1 rounded-lg bg-gray-100 dark:bg-white/5 p-1 self-start">
+				{(["fetch", "paste"] as DecryptMode[]).map((m) => (
+					<button
+						key={m}
+						type="button"
+						onClick={() => {
+							setMode(m);
+						}}
+						className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
+							mode === m
+								? "bg-indigo-600 text-white"
+								: "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+						}`}
+					>
+						{m === "fetch" ? "Fetch from URI" : "Paste bundle"}
+					</button>
+				))}
+			</div>
+
+			{mode === "fetch" ? (
+				<p className="text-xs text-gray-500 break-all">
+					Will fetch:{" "}
+					<span className="font-mono text-gray-600 dark:text-gray-400">{gatewayUrl}</span>
+				</p>
+			) : (
+				<div className="flex flex-col gap-1">
+					<textarea
+						rows={4}
+						placeholder={'{"v":1,"alg":"AES-256-GCM",…}'}
+						value={pastedBundle}
+						onChange={(e) => {
+							setPastedBundle(e.target.value);
+						}}
+						onBlur={() => {
+							setBundleTouched(true);
+						}}
+						aria-invalid={bundleTouched && bundleError !== undefined}
+						className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-xs text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 font-mono focus:outline-none focus:ring-2 resize-none ${
+							bundleTouched && bundleError !== undefined
+								? "border-red-500 dark:border-red-500 focus:ring-red-500"
+								: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+						}`}
+					/>
+					{bundleTouched && bundleError !== undefined && (
+						<p className="text-xs text-red-500 dark:text-red-400">{bundleError}</p>
+					)}
+				</div>
+			)}
+
+			<div className="flex flex-col gap-1">
+				<input
+					type="password"
+					placeholder="Passphrase"
+					value={passphrase}
+					onChange={(e) => {
+						setPassphrase(e.target.value);
+					}}
+					onBlur={() => {
+						setPassphraseTouched(true);
+					}}
+					aria-invalid={passphraseTouched && passphraseError !== undefined}
+					className={`rounded-lg bg-gray-50 dark:bg-white/5 border px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 ${
+						passphraseTouched && passphraseError !== undefined
+							? "border-red-500 dark:border-red-500 focus:ring-red-500"
+							: "border-gray-200 dark:border-white/10 focus:ring-indigo-500"
+					}`}
+				/>
+				{passphraseTouched && passphraseError !== undefined && (
+					<p className="text-xs text-red-500 dark:text-red-400">{passphraseError}</p>
+				)}
+			</div>
+
+			<input
+				type="text"
+				placeholder="Output filename (e.g. contract.pdf)"
+				value={filename}
+				onChange={(e) => {
+					setFilename(e.target.value);
+				}}
+				className="rounded-lg bg-gray-50 dark:bg-white/5 border border-gray-200 dark:border-white/10 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+			/>
+
+			{status === "done" ? (
+				<p className="text-xs text-green-500 dark:text-green-400">
+					✓ File downloaded.{" "}
+					<button
+						type="button"
+						onClick={() => {
+							setStatus("idle");
+							setErrorMsg(null);
+							setPassphrase("");
+						}}
+						className="underline text-gray-500 hover:text-gray-900 dark:hover:text-white"
+					>
+						Decrypt another
+					</button>
+				</p>
+			) : (
+				<button
+					type="button"
+					onClick={() => {
+						void handleDecrypt();
+					}}
+					disabled={
+						status === "working" ||
+						passphrase === "" ||
+						(mode === "paste" && pastedBundle.trim() === "")
+					}
+					className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors"
+				>
+					{status === "working" ? "Decrypting…" : "Decrypt & Download"}
+				</button>
+			)}
+
+			{status === "error" && errorMsg !== null && (
+				<p className="text-xs text-red-500 dark:text-red-400 rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2">
+					{errorMsg}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/src/lib/abi.ts
+++ b/src/lib/abi.ts
@@ -1,103 +1,314 @@
 export const TRUSTLEDGER_ABI = [
 	{
-		inputs: [{ internalType: "address", name: "arbitration_", type: "address" }],
+		inputs: [
+			{
+				internalType: "address",
+				name: "arbitration_",
+				type: "address",
+			},
+		],
 		stateMutability: "nonpayable",
 		type: "constructor",
 	},
-	{ inputs: [], name: "AlreadySet", type: "error" },
-	{ inputs: [], name: "CompletionPctOutOfRange", type: "error" },
-	{ inputs: [], name: "ContractNotFinished", type: "error" },
-	{ inputs: [], name: "DeadlineElapsed", type: "error" },
-	{ inputs: [], name: "DeadlineNotElapsed", type: "error" },
-	{ inputs: [], name: "EmptyHash", type: "error" },
-	{ inputs: [], name: "EmptyURI", type: "error" },
-	{ inputs: [], name: "EnforcedPause", type: "error" },
-	{ inputs: [], name: "EthTransferFailed", type: "error" },
-	{ inputs: [], name: "ExpectedPause", type: "error" },
-	{ inputs: [], name: "InsufficientFunds", type: "error" },
-	{ inputs: [], name: "InvalidAcceptanceWindow", type: "error" },
-	{ inputs: [], name: "InvalidArbitrationFee", type: "error" },
-	{ inputs: [], name: "InvalidBufferFactor", type: "error" },
-	{ inputs: [], name: "InvalidHoldBack", type: "error" },
-	{ inputs: [], name: "InvalidPreviousContract", type: "error" },
-	{ inputs: [], name: "InvalidSignature", type: "error" },
 	{
-		inputs: [{ internalType: "enum TrustLedger.Status", name: "current", type: "uint8" }],
+		inputs: [],
+		name: "AlreadySet",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "CompletionPctOutOfRange",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "ContractNotFinished",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "DeadlineElapsed",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "DeadlineNotElapsed",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "EmptyHash",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "EmptyURI",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "EnforcedPause",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "EthTransferFailed",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "ExpectedPause",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "InsufficientFunds",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "InvalidAcceptanceWindow",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "InvalidArbitrationFee",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "InvalidBufferFactor",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "InvalidHoldBack",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "InvalidPreviousContract",
+		type: "error",
+	},
+	{
+		inputs: [
+			{
+				internalType: "enum TrustLedger.Status",
+				name: "current",
+				type: "uint8",
+			},
+		],
 		name: "InvalidStatus",
 		type: "error",
 	},
-	{ inputs: [], name: "InvalidTokenParams", type: "error" },
-	{ inputs: [], name: "InvalidWarrantyPeriod", type: "error" },
-	{ inputs: [], name: "NotPauser", type: "error" },
-	{ inputs: [], name: "RatingAlreadySubmitted", type: "error" },
-	{ inputs: [], name: "RatingOutOfRange", type: "error" },
-	{ inputs: [], name: "ReentrancyGuardReentrantCall", type: "error" },
-	{ inputs: [], name: "SelfContract", type: "error" },
-	{ inputs: [], name: "TokenTransferFailed", type: "error" },
-	{ inputs: [], name: "Unauthorized", type: "error" },
-	{ inputs: [], name: "WindowElapsed", type: "error" },
-	{ inputs: [], name: "WindowNotElapsed", type: "error" },
-	{ inputs: [], name: "ZeroAddress", type: "error" },
+	{
+		inputs: [],
+		name: "InvalidTokenParams",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "InvalidWarrantyPeriod",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "NotPauser",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "RatingAlreadySubmitted",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "RatingOutOfRange",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "ReentrancyGuardReentrantCall",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "SelfContract",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "TokenTransferFailed",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "Unauthorized",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "WindowElapsed",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "WindowNotElapsed",
+		type: "error",
+	},
+	{
+		inputs: [],
+		name: "ZeroAddress",
+		type: "error",
+	},
 	{
 		anonymous: false,
-		inputs: [{ indexed: true, internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "ContractAccepted",
 		type: "event",
 	},
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "newId", type: "uint256" },
-			{ indexed: true, internalType: "uint256", name: "previousId", type: "uint256" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "newId",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "previousId",
+				type: "uint256",
+			},
 		],
 		name: "ContractAmended",
 		type: "event",
 	},
 	{
 		anonymous: false,
-		inputs: [{ indexed: true, internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "ContractCancelled",
 		type: "event",
 	},
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "id", type: "uint256" },
-			{ indexed: true, internalType: "address", name: "client", type: "address" },
-			{ indexed: true, internalType: "address", name: "freelancer", type: "address" },
-			{ indexed: false, internalType: "uint256", name: "amount", type: "uint256" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "address",
+				name: "client",
+				type: "address",
+			},
+			{
+				indexed: true,
+				internalType: "address",
+				name: "freelancer",
+				type: "address",
+			},
+			{
+				indexed: false,
+				internalType: "uint256",
+				name: "amount",
+				type: "uint256",
+			},
 		],
-		name: "ContractCreated",
+		name: "ContractProposed",
 		type: "event",
 	},
 	{
 		anonymous: false,
-		inputs: [{ indexed: true, internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "ContractRejected",
 		type: "event",
 	},
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "id", type: "uint256" },
-			{ indexed: true, internalType: "address", name: "to", type: "address" },
-			{ indexed: true, internalType: "uint256", name: "amount", type: "uint256" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "address",
+				name: "to",
+				type: "address",
+			},
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "amount",
+				type: "uint256",
+			},
 		],
 		name: "FundsReleased",
 		type: "event",
 	},
 	{
 		anonymous: false,
-		inputs: [{ indexed: false, internalType: "address", name: "account", type: "address" }],
+		inputs: [
+			{
+				indexed: false,
+				internalType: "address",
+				name: "account",
+				type: "address",
+			},
+		],
 		name: "Paused",
 		type: "event",
 	},
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "id", type: "uint256" },
-			{ indexed: true, internalType: "bytes32", name: "powHash", type: "bytes32" },
-			{ indexed: false, internalType: "string", name: "powURI", type: "string" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "bytes32",
+				name: "powHash",
+				type: "bytes32",
+			},
+			{
+				indexed: false,
+				internalType: "string",
+				name: "powURI",
+				type: "string",
+			},
 		],
 		name: "ProofSubmitted",
 		type: "event",
@@ -105,9 +316,24 @@ export const TRUSTLEDGER_ABI = [
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "id", type: "uint256" },
-			{ indexed: true, internalType: "address", name: "rater", type: "address" },
-			{ indexed: false, internalType: "uint8", name: "score", type: "uint8" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "address",
+				name: "rater",
+				type: "address",
+			},
+			{
+				indexed: true,
+				internalType: "uint8",
+				name: "score",
+				type: "uint8",
+			},
 		],
 		name: "RatingSubmitted",
 		type: "event",
@@ -115,39 +341,88 @@ export const TRUSTLEDGER_ABI = [
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "id", type: "uint256" },
-			{ indexed: true, internalType: "uint256", name: "completionPct", type: "uint256" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "completionPct",
+				type: "uint256",
+			},
 		],
 		name: "RulingExecuted",
 		type: "event",
 	},
 	{
 		anonymous: false,
-		inputs: [{ indexed: false, internalType: "address", name: "account", type: "address" }],
+		inputs: [
+			{
+				indexed: false,
+				internalType: "address",
+				name: "account",
+				type: "address",
+			},
+		],
 		name: "Unpaused",
 		type: "event",
 	},
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "id", type: "uint256" },
-			{ indexed: true, internalType: "address", name: "freelancer", type: "address" },
-			{ indexed: true, internalType: "uint256", name: "amount", type: "uint256" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "address",
+				name: "freelancer",
+				type: "address",
+			},
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "amount",
+				type: "uint256",
+			},
 		],
 		name: "WarrantyFundsClaimed",
 		type: "event",
 	},
 	{
 		anonymous: false,
-		inputs: [{ indexed: true, internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "WorkApproved",
 		type: "event",
 	},
 	{
 		anonymous: false,
 		inputs: [
-			{ indexed: true, internalType: "uint256", name: "id", type: "uint256" },
-			{ indexed: true, internalType: "uint256", name: "arbitrationId", type: "uint256" },
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				indexed: true,
+				internalType: "uint256",
+				name: "arbitrationId",
+				type: "uint256",
+			},
 		],
 		name: "WorkDisputed",
 		type: "event",
@@ -155,94 +430,193 @@ export const TRUSTLEDGER_ABI = [
 	{
 		inputs: [],
 		name: "ARBITRATION",
-		outputs: [{ internalType: "contract IArbitration", name: "", type: "address" }],
+		outputs: [
+			{
+				internalType: "contract IArbitration",
+				name: "",
+				type: "address",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "BPS_DENOMINATOR",
-		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
+		inputs: [],
+		name: "FRIVOLOUS_DISPUTE_THRESHOLD",
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "MAX_ARBITRATION_FEE_BPS",
-		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "MAX_HOLD_BACK_BPS",
-		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "MIN_ACCEPTANCE_WINDOW",
-		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "MIN_BUFFER_FACTOR",
-		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "MIN_HOLD_BACK_BPS",
-		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
+		stateMutability: "view",
+		type: "function",
+	},
+	{
+		inputs: [],
+		name: "POOR_WORK_THRESHOLD",
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [
-			{ internalType: "uint256", name: "id", type: "uint256" },
-			{ internalType: "uint8", name: "v", type: "uint8" },
-			{ internalType: "bytes32", name: "r", type: "bytes32" },
-			{ internalType: "bytes32", name: "s", type: "bytes32" },
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
 		],
 		name: "acceptContract",
 		outputs: [],
-		stateMutability: "nonpayable",
+		stateMutability: "payable",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "approveWork",
 		outputs: [],
 		stateMutability: "nonpayable",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
-		name: "cancelPending",
+		inputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
+		name: "cancelProposal",
 		outputs: [],
 		stateMutability: "nonpayable",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "claimAfterAcceptanceWindow",
 		outputs: [],
 		stateMutability: "nonpayable",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "claimAfterDeadlineMiss",
 		outputs: [],
 		stateMutability: "nonpayable",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "claimWarrantyFunds",
 		outputs: [],
 		stateMutability: "nonpayable",
@@ -250,25 +624,12 @@ export const TRUSTLEDGER_ABI = [
 	},
 	{
 		inputs: [
-			{ internalType: "address", name: "freelancer", type: "address" },
-			{ internalType: "bytes32", name: "contractHash", type: "bytes32" },
-			{ internalType: "string", name: "contractURI", type: "string" },
-			{ internalType: "uint256", name: "estimatedDuration", type: "uint256" },
-			{ internalType: "uint256", name: "bufferFactor", type: "uint256" },
-			{ internalType: "uint256", name: "acceptanceWindow", type: "uint256" },
-			{ internalType: "uint16", name: "arbitrationFeeBps", type: "uint16" },
-			{ internalType: "uint16", name: "holdBackBps", type: "uint16" },
-			{ internalType: "uint64", name: "warrantyPeriod", type: "uint64" },
-			{ internalType: "address", name: "token", type: "address" },
-			{ internalType: "uint256", name: "tokenAmount", type: "uint256" },
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
 		],
-		name: "createContract",
-		outputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
-		stateMutability: "payable",
-		type: "function",
-	},
-	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
 		name: "disputeWork",
 		outputs: [],
 		stateMutability: "payable",
@@ -276,8 +637,16 @@ export const TRUSTLEDGER_ABI = [
 	},
 	{
 		inputs: [
-			{ internalType: "uint256", name: "id", type: "uint256" },
-			{ internalType: "uint256", name: "completionPct", type: "uint256" },
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				internalType: "uint256",
+				name: "completionPct",
+				type: "uint256",
+			},
 		],
 		name: "executeRuling",
 		outputs: [],
@@ -285,34 +654,120 @@ export const TRUSTLEDGER_ABI = [
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "getContract",
 		outputs: [
 			{
 				components: [
-					{ internalType: "address", name: "client", type: "address" },
-					{ internalType: "uint16", name: "arbitrationFeeBps", type: "uint16" },
-					{ internalType: "uint16", name: "holdBackBps", type: "uint16" },
-					{ internalType: "enum TrustLedger.Status", name: "status", type: "uint8" },
-					{ internalType: "address", name: "freelancer", type: "address" },
-					{ internalType: "uint64", name: "warrantyDeadline", type: "uint64" },
-					{ internalType: "uint64", name: "projectDeadline", type: "uint64" },
-					{ internalType: "uint64", name: "acceptanceWindow", type: "uint64" },
-					{ internalType: "uint64", name: "acceptanceDeadline", type: "uint64" },
-					{ internalType: "uint64", name: "warrantyPeriod", type: "uint64" },
-					{ internalType: "uint256", name: "amount", type: "uint256" },
-					{ internalType: "uint256", name: "holdBackAmount", type: "uint256" },
-					{ internalType: "uint256", name: "arbitrationId", type: "uint256" },
-					{ internalType: "bytes32", name: "contractHash", type: "bytes32" },
-					{ internalType: "string", name: "contractURI", type: "string" },
-					{ internalType: "bytes32", name: "proofOfWorkHash", type: "bytes32" },
-					{ internalType: "string", name: "proofOfWorkURI", type: "string" },
-					{ internalType: "address", name: "token", type: "address" },
-					{ internalType: "uint256", name: "usdValueAtCreation", type: "uint256" },
-					{ internalType: "uint256", name: "previousContractId", type: "uint256" },
+					{
+						internalType: "address",
+						name: "client",
+						type: "address",
+					},
+					{
+						internalType: "uint16",
+						name: "arbitrationFeeBps",
+						type: "uint16",
+					},
+					{
+						internalType: "uint16",
+						name: "holdBackBps",
+						type: "uint16",
+					},
+					{
+						internalType: "enum TrustLedger.Status",
+						name: "status",
+						type: "uint8",
+					},
+					{
+						internalType: "address",
+						name: "freelancer",
+						type: "address",
+					},
+					{
+						internalType: "uint64",
+						name: "warrantyDeadline",
+						type: "uint64",
+					},
+					{
+						internalType: "uint64",
+						name: "projectDeadline",
+						type: "uint64",
+					},
+					{
+						internalType: "uint64",
+						name: "acceptanceWindow",
+						type: "uint64",
+					},
+					{
+						internalType: "uint64",
+						name: "acceptanceDeadline",
+						type: "uint64",
+					},
+					{
+						internalType: "uint64",
+						name: "warrantyPeriod",
+						type: "uint64",
+					},
+					{
+						internalType: "uint256",
+						name: "amount",
+						type: "uint256",
+					},
+					{
+						internalType: "uint256",
+						name: "holdBackAmount",
+						type: "uint256",
+					},
+					{
+						internalType: "uint256",
+						name: "arbitrationId",
+						type: "uint256",
+					},
+					{
+						internalType: "bytes32",
+						name: "contractHash",
+						type: "bytes32",
+					},
+					{
+						internalType: "string",
+						name: "contractURI",
+						type: "string",
+					},
+					{
+						internalType: "bytes32",
+						name: "proofOfWorkHash",
+						type: "bytes32",
+					},
+					{
+						internalType: "string",
+						name: "proofOfWorkURI",
+						type: "string",
+					},
+					{
+						internalType: "address",
+						name: "token",
+						type: "address",
+					},
+					{
+						internalType: "uint256",
+						name: "usdValueAtCreation",
+						type: "uint256",
+					},
+					{
+						internalType: "uint256",
+						name: "previousContractId",
+						type: "uint256",
+					},
 				],
 				internalType: "struct TrustLedger.EscrowContract",
-				name: "",
+				name: "result",
 				type: "tuple",
 			},
 		],
@@ -320,21 +775,39 @@ export const TRUSTLEDGER_ABI = [
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "address", name: "pauser_", type: "address" }],
+		inputs: [
+			{
+				internalType: "address",
+				name: "pauser_",
+				type: "address",
+			},
+		],
 		name: "initPauser",
 		outputs: [],
 		stateMutability: "nonpayable",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "address", name: "feed_", type: "address" }],
+		inputs: [
+			{
+				internalType: "address",
+				name: "feed_",
+				type: "address",
+			},
+		],
 		name: "initPriceFeed",
 		outputs: [],
 		stateMutability: "nonpayable",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "address", name: "registry_", type: "address" }],
+		inputs: [
+			{
+				internalType: "address",
+				name: "registry_",
+				type: "address",
+			},
+		],
 		name: "initReputationRegistry",
 		outputs: [],
 		stateMutability: "nonpayable",
@@ -342,8 +815,16 @@ export const TRUSTLEDGER_ABI = [
 	},
 	{
 		inputs: [
-			{ internalType: "uint256", name: "newId", type: "uint256" },
-			{ internalType: "uint256", name: "previousId", type: "uint256" },
+			{
+				internalType: "uint256",
+				name: "newId",
+				type: "uint256",
+			},
+			{
+				internalType: "uint256",
+				name: "previousId",
+				type: "uint256",
+			},
 		],
 		name: "linkAmendment",
 		outputs: [],
@@ -353,7 +834,13 @@ export const TRUSTLEDGER_ABI = [
 	{
 		inputs: [],
 		name: "nextId",
-		outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "",
+				type: "uint256",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
@@ -367,26 +854,119 @@ export const TRUSTLEDGER_ABI = [
 	{
 		inputs: [],
 		name: "paused",
-		outputs: [{ internalType: "bool", name: "", type: "bool" }],
+		outputs: [
+			{
+				internalType: "bool",
+				name: "",
+				type: "bool",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "pauser",
-		outputs: [{ internalType: "address", name: "", type: "address" }],
+		outputs: [
+			{
+				internalType: "address",
+				name: "",
+				type: "address",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [],
 		name: "priceFeed",
-		outputs: [{ internalType: "contract AggregatorV3Interface", name: "", type: "address" }],
+		outputs: [
+			{
+				internalType: "contract AggregatorV3Interface",
+				name: "",
+				type: "address",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
-		inputs: [{ internalType: "uint256", name: "id", type: "uint256" }],
+		inputs: [
+			{
+				internalType: "address",
+				name: "client",
+				type: "address",
+			},
+			{
+				internalType: "bytes32",
+				name: "contractHash",
+				type: "bytes32",
+			},
+			{
+				internalType: "string",
+				name: "contractURI",
+				type: "string",
+			},
+			{
+				internalType: "uint256",
+				name: "estimatedDuration",
+				type: "uint256",
+			},
+			{
+				internalType: "uint256",
+				name: "bufferFactor",
+				type: "uint256",
+			},
+			{
+				internalType: "uint256",
+				name: "acceptanceWindow",
+				type: "uint256",
+			},
+			{
+				internalType: "uint16",
+				name: "arbitrationFeeBps",
+				type: "uint16",
+			},
+			{
+				internalType: "uint16",
+				name: "holdBackBps",
+				type: "uint16",
+			},
+			{
+				internalType: "uint64",
+				name: "warrantyPeriod",
+				type: "uint64",
+			},
+			{
+				internalType: "address",
+				name: "token",
+				type: "address",
+			},
+			{
+				internalType: "uint256",
+				name: "amount",
+				type: "uint256",
+			},
+		],
+		name: "proposeContract",
+		outputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+	{
+		inputs: [
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+		],
 		name: "rejectContract",
 		outputs: [],
 		stateMutability: "nonpayable",
@@ -395,15 +975,33 @@ export const TRUSTLEDGER_ABI = [
 	{
 		inputs: [],
 		name: "reputationRegistry",
-		outputs: [{ internalType: "contract IReputationRegistry", name: "", type: "address" }],
+		outputs: [
+			{
+				internalType: "contract IReputationRegistry",
+				name: "",
+				type: "address",
+			},
+		],
 		stateMutability: "view",
 		type: "function",
 	},
 	{
 		inputs: [
-			{ internalType: "uint256", name: "id", type: "uint256" },
-			{ internalType: "bytes32", name: "powHash", type: "bytes32" },
-			{ internalType: "string", name: "powURI", type: "string" },
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				internalType: "bytes32",
+				name: "powHash",
+				type: "bytes32",
+			},
+			{
+				internalType: "string",
+				name: "powURI",
+				type: "string",
+			},
 		],
 		name: "submitProofOfWork",
 		outputs: [],
@@ -412,8 +1010,16 @@ export const TRUSTLEDGER_ABI = [
 	},
 	{
 		inputs: [
-			{ internalType: "uint256", name: "id", type: "uint256" },
-			{ internalType: "uint8", name: "score", type: "uint8" },
+			{
+				internalType: "uint256",
+				name: "id",
+				type: "uint256",
+			},
+			{
+				internalType: "uint8",
+				name: "score",
+				type: "uint8",
+			},
 		],
 		name: "submitRating",
 		outputs: [],

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -42,7 +42,11 @@ function fromHex(hex: string): Uint8Array<ArrayBuffer> {
 // intentionally runs many hash iterations to make brute-force guessing expensive.
 // A unique random salt ensures two encryptions with the same passphrase produce
 // different keys, preventing precomputed rainbow-table attacks.
-async function deriveKey(passphrase: string, salt: Uint8Array<ArrayBuffer>): Promise<CryptoKey> {
+async function deriveKey(
+	passphrase: string,
+	salt: Uint8Array<ArrayBuffer>,
+	iterations: number = ITERATIONS,
+): Promise<CryptoKey> {
 	// Step 1: import the passphrase as raw key material (not a usable key yet).
 	const raw = await crypto.subtle.importKey(
 		"raw",
@@ -52,8 +56,11 @@ async function deriveKey(passphrase: string, salt: Uint8Array<ArrayBuffer>): Pro
 		["deriveKey"],
 	);
 	// Step 2: stretch it into a proper AES-256 key via PBKDF2-SHA256.
+	// The iteration count must match what was used at encryption time; on decrypt it
+	// comes from the bundle's `iter` field so future bundles can raise it without
+	// breaking older ones.
 	return await crypto.subtle.deriveKey(
-		{ name: "PBKDF2", salt, iterations: ITERATIONS, hash: "SHA-256" },
+		{ name: "PBKDF2", salt, iterations, hash: "SHA-256" },
 		raw,
 		{ name: "AES-GCM", length: 256 },
 		false, // not extractable — key stays inside the crypto engine
@@ -104,7 +111,7 @@ export async function decryptFile(data: ArrayBuffer, passphrase: string): Promis
 	const iv = fromHex(bundle.iv);
 	// Wrap in new Uint8Array() to ensure Uint8Array<ArrayBuffer> for Web Crypto.
 	const ct = new Uint8Array(Uint8Array.from(atob(bundle.ct), (c) => c.charCodeAt(0)));
-	const key = await deriveKey(passphrase, salt);
+	const key = await deriveKey(passphrase, salt, bundle.iter);
 	// If the passphrase is wrong or the ciphertext was tampered, GCM authentication fails
 	// and subtle.decrypt throws a DOMException("OperationError") — caught by the UI above.
 	return await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);

--- a/src/lib/magicLink.ts
+++ b/src/lib/magicLink.ts
@@ -7,8 +7,8 @@
 
 export interface MagicLinkPayload {
 	contractId: string;
-	freelancerEmail: string;
-	freelancerAddress: string;
+	clientEmail: string;
+	clientAddress: string;
 	nonce: string; // random UUID included so two tokens for the same contract are never identical
 	exp: number; // unix seconds — checked in verifyMagicToken
 }

--- a/test/TrustLedger.test.ts
+++ b/test/TrustLedger.test.ts
@@ -9,7 +9,7 @@
 //   - Impersonating an address requires hardhat_impersonateAccount
 //   - BigInt (not number) for all on-chain integers (ethers v6 returns BigInt)
 //   - `expect` from Chai replaces assertEq / assertTrue
-//   - acceptContract now requires an ECDSA signature from the freelancer wallet
+//   - the freelancer proposes (proposeContract); the client accepts by funding the escrow
 
 import { expect } from "chai";
 import { ethers } from "hardhat";
@@ -96,8 +96,9 @@ describe("TrustLedger", function () {
 
 	// ─── Helper Functions ────────────────────────────────────────────────────
 
-	// Creates an escrow contract with optional overrides.
-	// Passes address(0) and 0 for the new token/tokenAmount params (ETH escrow).
+	// Freelancer proposes an escrow contract with optional overrides. No funds move yet;
+	// the contract sits PENDING until the client accepts. Passes address(0) for the token
+	// param (ETH escrow); the escrow amount is a parameter the client will lock on acceptance.
 	async function createContract(opts?: {
 		holdBackBps?: number;
 		warrantyPeriod?: bigint;
@@ -107,8 +108,8 @@ describe("TrustLedger", function () {
 		const warranty = opts?.warrantyPeriod ?? 0n;
 		const amount = opts?.amount ?? AMOUNT;
 
-		const tx = await trustLedger.connect(client).createContract(
-			await freelancer.getAddress(),
+		const tx = await trustLedger.connect(freelancer).proposeContract(
+			await client.getAddress(),
 			CONTRACT_HASH,
 			"ipfs://QmContract",
 			ESTIMATED_DURATION,
@@ -118,8 +119,7 @@ describe("TrustLedger", function () {
 			holdBack,
 			warranty,
 			ethers.ZeroAddress, // token = address(0) → ETH escrow
-			0n, // tokenAmount = 0 for ETH escrows
-			{ value: amount },
+			amount, // escrow amount the client will lock
 		);
 
 		const receipt = await tx.wait();
@@ -132,34 +132,16 @@ describe("TrustLedger", function () {
 					return null;
 				}
 			})
-			.find((e) => e?.name === "ContractCreated");
+			.find((e) => e?.name === "ContractProposed");
 
 		return event?.args[0] as bigint;
 	}
 
-	// Signs an EIP-191 acceptance message for the given contract ID.
-	// Must match the on-chain ecrecover call in acceptContract().
-	async function signAccept(id: bigint): Promise<{ v: number; r: string; s: string }> {
-		const freelancerAddr = await freelancer.getAddress();
-
-		// innerHash = keccak256(abi.encodePacked(id, freelancerAddress))
-		const innerHash = ethers.solidityPackedKeccak256(
-			["uint256", "address"],
-			[id, freelancerAddr],
-		);
-
-		// eth_sign adds the EIP-191 prefix before signing.
-		// ethers.Signer.signMessage applies "\x19Ethereum Signed Message:\n32" automatically.
-		const sig = await freelancer.signMessage(ethers.getBytes(innerHash));
-		const { v, r, s } = ethers.Signature.from(sig);
-		return { v, r, s };
-	}
-
-	// Creates a contract AND has the freelancer sign and call acceptContract.
+	// Proposes a contract AND has the client accept it, funding the escrow.
 	async function createAndAccept(opts?: Parameters<typeof createContract>[0]) {
 		const id = await createContract(opts);
-		const { v, r, s } = await signAccept(id);
-		await trustLedger.connect(freelancer).acceptContract(id, v, r, s);
+		const amount = opts?.amount ?? AMOUNT;
+		await trustLedger.connect(client).acceptContract(id, { value: amount });
 		return id;
 	}
 
@@ -215,17 +197,20 @@ describe("TrustLedger", function () {
 			expect(c.token).to.equal(ethers.ZeroAddress); // ETH escrow
 		});
 
-		it("should allow freelancer to accept with valid signature", async function () {
+		it("should allow client to accept by funding the escrow", async function () {
 			const id = await createContract();
-			const { v, r, s } = await signAccept(id);
 
 			// `emit` checks that the transaction emitted ContractAccepted(id).
-			await expect(trustLedger.connect(freelancer).acceptContract(id, v, r, s))
+			await expect(trustLedger.connect(client).acceptContract(id, { value: AMOUNT }))
 				.to.emit(trustLedger, "ContractAccepted")
 				.withArgs(id);
 
 			const c = await trustLedger.getContract(id);
 			expect(c.status).to.equal(STATUS.ACTIVE);
+			// Funds are now held by the escrow contract.
+			expect(await ethers.provider.getBalance(await trustLedger.getAddress())).to.equal(
+				AMOUNT,
+			);
 		});
 
 		it("should allow freelancer to submit proof of work", async function () {
@@ -256,21 +241,21 @@ describe("TrustLedger", function () {
 		});
 	});
 
-	// ─── Cancel Pending ───────────────────────────────────────────────────────
+	// ─── Cancel Proposal ────────────────────────────────────────────────────────
 
-	describe("Cancel Pending", function () {
-		it("should refund client when they cancel a pending contract", async function () {
+	describe("Cancel Proposal", function () {
+		it("should let the freelancer withdraw a pending proposal without moving funds", async function () {
 			const id = await createContract();
 			const clientAddr = await client.getAddress();
 			const balBefore = await ethers.provider.getBalance(clientAddr);
 
-			const tx = await trustLedger.connect(client).cancelPending(id);
-			const receipt = await tx.wait();
-			if (receipt === null) throw new Error("transaction not mined");
-			const gasUsed = receipt.gasUsed * receipt.gasPrice;
+			await expect(trustLedger.connect(freelancer).cancelProposal(id))
+				.to.emit(trustLedger, "ContractCancelled")
+				.withArgs(id);
 
+			// No funds were ever held, so the client's balance is unchanged.
 			const balAfter = await ethers.provider.getBalance(clientAddr);
-			expect(balAfter - balBefore + gasUsed).to.equal(AMOUNT);
+			expect(balAfter).to.equal(balBefore);
 
 			const c = await trustLedger.getContract(id);
 			expect(c.status).to.equal(STATUS.CANCELLED);
@@ -280,22 +265,26 @@ describe("TrustLedger", function () {
 	// ─── Rejection ────────────────────────────────────────────────────────────
 
 	describe("Rejection", function () {
-		it("should refund client when freelancer rejects", async function () {
+		it("should let the client reject a proposal without moving funds", async function () {
 			const id = await createContract();
 			const clientAddr = await client.getAddress();
 			const balBefore = await ethers.provider.getBalance(clientAddr);
 
-			await expect(trustLedger.connect(freelancer).rejectContract(id))
-				.to.emit(trustLedger, "ContractRejected")
-				.withArgs(id);
+			const tx = await trustLedger.connect(client).rejectContract(id);
+			const receipt = await tx.wait();
+			if (receipt === null) throw new Error("transaction not mined");
+			const gasUsed = receipt.gasUsed * receipt.gasPrice;
 
+			await expect(tx).to.emit(trustLedger, "ContractRejected").withArgs(id);
+
+			// No escrow was held; the only balance delta is the rejection gas.
 			const balAfter = await ethers.provider.getBalance(clientAddr);
-			expect(balAfter - balBefore).to.equal(AMOUNT);
+			expect(balBefore - balAfter).to.equal(gasUsed);
 		});
 
 		it("should set status to CANCELLED after rejection", async function () {
 			const id = await createContract();
-			await trustLedger.connect(freelancer).rejectContract(id);
+			await trustLedger.connect(client).rejectContract(id);
 			const c = await trustLedger.getContract(id);
 			expect(c.status).to.equal(STATUS.CANCELLED);
 		});
@@ -523,11 +512,11 @@ describe("TrustLedger", function () {
 	// ─── Revert Cases ────────────────────────────────────────────────────────
 
 	describe("Revert Cases", function () {
-		it("should revert createContract with zero address freelancer", async function () {
+		it("should revert proposeContract with zero address client", async function () {
 			await expect(
 				trustLedger
-					.connect(client)
-					.createContract(
+					.connect(freelancer)
+					.proposeContract(
 						ethers.ZeroAddress,
 						CONTRACT_HASH,
 						"ipfs://",
@@ -538,17 +527,36 @@ describe("TrustLedger", function () {
 						0,
 						0,
 						ethers.ZeroAddress,
-						0n,
-						{ value: AMOUNT },
+						AMOUNT,
 					),
 			).to.be.revertedWithCustomError(trustLedger, "ZeroAddress");
 		});
 
-		it("should revert createContract with self as freelancer", async function () {
+		it("should revert proposeContract with self as client", async function () {
 			await expect(
 				trustLedger
-					.connect(client)
-					.createContract(
+					.connect(freelancer)
+					.proposeContract(
+						await freelancer.getAddress(),
+						CONTRACT_HASH,
+						"ipfs://",
+						ESTIMATED_DURATION,
+						BUFFER_FACTOR,
+						ACCEPTANCE_WINDOW,
+						ARB_FEE_BPS,
+						0,
+						0,
+						ethers.ZeroAddress,
+						AMOUNT,
+					),
+			).to.be.revertedWithCustomError(trustLedger, "SelfContract");
+		});
+
+		it("should revert proposeContract with 0 amount", async function () {
+			await expect(
+				trustLedger
+					.connect(freelancer)
+					.proposeContract(
 						await client.getAddress(),
 						CONTRACT_HASH,
 						"ipfs://",
@@ -560,49 +568,24 @@ describe("TrustLedger", function () {
 						0,
 						ethers.ZeroAddress,
 						0n,
-						{ value: AMOUNT },
-					),
-			).to.be.revertedWithCustomError(trustLedger, "SelfContract");
-		});
-
-		it("should revert createContract with 0 value", async function () {
-			await expect(
-				trustLedger
-					.connect(client)
-					.createContract(
-						await freelancer.getAddress(),
-						CONTRACT_HASH,
-						"ipfs://",
-						ESTIMATED_DURATION,
-						BUFFER_FACTOR,
-						ACCEPTANCE_WINDOW,
-						ARB_FEE_BPS,
-						0,
-						0,
-						ethers.ZeroAddress,
-						0n,
-						{ value: 0 },
 					),
 			).to.be.revertedWithCustomError(trustLedger, "InsufficientFunds");
 		});
 
-		it("should revert acceptContract when not freelancer", async function () {
+		it("should revert acceptContract when not client", async function () {
 			const id = await createContract();
-			const { v, r, s } = await signAccept(id);
-			// Caller is stranger (not the freelancer) → Unauthorized.
+			// Caller is stranger (not the client) → Unauthorized.
 			await expect(
-				trustLedger.connect(stranger).acceptContract(id, v, r, s),
+				trustLedger.connect(stranger).acceptContract(id, { value: AMOUNT }),
 			).to.be.revertedWithCustomError(trustLedger, "Unauthorized");
 		});
 
-		it("should revert acceptContract with bad signature", async function () {
+		it("should revert acceptContract with wrong value", async function () {
 			const id = await createContract();
-			// Sign with a wrong address - ecrecover will return a different address.
-			const wrongSig = await stranger.signMessage(ethers.toUtf8Bytes("wrong message"));
-			const { v, r, s } = ethers.Signature.from(wrongSig);
+			// Funding with less than the proposed amount is rejected.
 			await expect(
-				trustLedger.connect(freelancer).acceptContract(id, v, r, s),
-			).to.be.revertedWithCustomError(trustLedger, "InvalidSignature");
+				trustLedger.connect(client).acceptContract(id, { value: AMOUNT - 1n }),
+			).to.be.revertedWithCustomError(trustLedger, "InsufficientFunds");
 		});
 
 		it("should revert approveWork when not client", async function () {
@@ -664,9 +647,9 @@ describe("TrustLedger", function () {
 		it("should revert invalid buffer factor", async function () {
 			await expect(
 				trustLedger
-					.connect(client)
-					.createContract(
-						await freelancer.getAddress(),
+					.connect(freelancer)
+					.proposeContract(
+						await client.getAddress(),
 						CONTRACT_HASH,
 						"ipfs://",
 						ESTIMATED_DURATION,
@@ -676,8 +659,7 @@ describe("TrustLedger", function () {
 						0,
 						0,
 						ethers.ZeroAddress,
-						0n,
-						{ value: AMOUNT },
+						AMOUNT,
 					),
 			).to.be.revertedWithCustomError(trustLedger, "InvalidBufferFactor");
 		});
@@ -685,9 +667,9 @@ describe("TrustLedger", function () {
 		it("should revert invalid acceptance window", async function () {
 			await expect(
 				trustLedger
-					.connect(client)
-					.createContract(
-						await freelancer.getAddress(),
+					.connect(freelancer)
+					.proposeContract(
+						await client.getAddress(),
 						CONTRACT_HASH,
 						"ipfs://",
 						ESTIMATED_DURATION,
@@ -697,8 +679,7 @@ describe("TrustLedger", function () {
 						0,
 						0,
 						ethers.ZeroAddress,
-						0n,
-						{ value: AMOUNT },
+						AMOUNT,
 					),
 			).to.be.revertedWithCustomError(trustLedger, "InvalidAcceptanceWindow");
 		});
@@ -736,6 +717,7 @@ describe("TrustLedger", function () {
 			await token.connect(client).approve(await trustLedger.getAddress(), TOKEN_AMOUNT * 10n);
 		});
 
+		// Freelancer proposes a token escrow (no tokens move yet).
 		async function createERC20Contract(opts?: {
 			holdBackBps?: number;
 			warrantyPeriod?: bigint;
@@ -744,9 +726,9 @@ describe("TrustLedger", function () {
 			const warranty = opts?.warrantyPeriod ?? 0n;
 
 			const tx = await trustLedger
-				.connect(client)
-				.createContract(
-					await freelancer.getAddress(),
+				.connect(freelancer)
+				.proposeContract(
+					await client.getAddress(),
 					CONTRACT_HASH,
 					"ipfs://QmContract",
 					ESTIMATED_DURATION,
@@ -757,7 +739,6 @@ describe("TrustLedger", function () {
 					warranty,
 					await token.getAddress(),
 					TOKEN_AMOUNT,
-					{ value: 0n },
 				);
 			const receipt = await tx.wait();
 			const event = receipt?.logs
@@ -768,26 +749,33 @@ describe("TrustLedger", function () {
 						return null;
 					}
 				})
-				.find((e) => e?.name === "ContractCreated");
+				.find((e) => e?.name === "ContractProposed");
 			return event?.args[0] as bigint;
 		}
 
-		it("should pull tokens from client on createContract", async function () {
+		// Client accepts a token escrow, pulling TOKEN_AMOUNT via transferFrom (no ETH value).
+		async function acceptERC20(id: bigint) {
+			await trustLedger.connect(client).acceptContract(id);
+		}
+
+		it("should pull tokens from client on acceptContract", async function () {
 			const contractAddr = await trustLedger.getAddress();
 			const before = await token.balanceOf(contractAddr);
 
-			await createERC20Contract();
+			const id = await createERC20Contract();
+			// Tokens are only pulled when the client accepts and funds.
+			expect((await token.balanceOf(contractAddr)) - before).to.equal(0n);
+			await acceptERC20(id);
 
 			expect((await token.balanceOf(contractAddr)) - before).to.equal(TOKEN_AMOUNT);
-			const c = await trustLedger.getContract(0n);
+			const c = await trustLedger.getContract(id);
 			expect(c.token).to.equal(await token.getAddress());
 			expect(c.amount).to.equal(TOKEN_AMOUNT);
 		});
 
 		it("should pay freelancer in tokens on approval", async function () {
 			const id = await createERC20Contract();
-			const { v, r, s } = await signAccept(id);
-			await trustLedger.connect(freelancer).acceptContract(id, v, r, s);
+			await acceptERC20(id);
 			await trustLedger.connect(freelancer).submitProofOfWork(id, POW_HASH, "ipfs://QmPoW");
 
 			const freelancerAddr = await freelancer.getAddress();
@@ -796,20 +784,20 @@ describe("TrustLedger", function () {
 			expect((await token.balanceOf(freelancerAddr)) - before).to.equal(TOKEN_AMOUNT);
 		});
 
-		it("should refund tokens to client on rejection", async function () {
+		it("should not move tokens when the client rejects an unfunded proposal", async function () {
 			const id = await createERC20Contract();
 			const clientAddr = await client.getAddress();
 			const before = await token.balanceOf(clientAddr);
-			await trustLedger.connect(freelancer).rejectContract(id);
-			expect((await token.balanceOf(clientAddr)) - before).to.equal(TOKEN_AMOUNT);
+			await trustLedger.connect(client).rejectContract(id);
+			expect(await token.balanceOf(clientAddr)).to.equal(before);
 		});
 
-		it("should refund tokens to client on cancelPending", async function () {
+		it("should not move tokens when the freelancer withdraws a proposal", async function () {
 			const id = await createERC20Contract();
 			const clientAddr = await client.getAddress();
 			const before = await token.balanceOf(clientAddr);
-			await trustLedger.connect(client).cancelPending(id);
-			expect((await token.balanceOf(clientAddr)) - before).to.equal(TOKEN_AMOUNT);
+			await trustLedger.connect(freelancer).cancelProposal(id);
+			expect(await token.balanceOf(clientAddr)).to.equal(before);
 		});
 
 		it("should hold back tokens correctly on approval with warranty", async function () {
@@ -817,8 +805,7 @@ describe("TrustLedger", function () {
 				holdBackBps: 1000,
 				warrantyPeriod: 7n * 24n * 3600n,
 			});
-			const { v, r, s } = await signAccept(id);
-			await trustLedger.connect(freelancer).acceptContract(id, v, r, s);
+			await acceptERC20(id);
 			await trustLedger.connect(freelancer).submitProofOfWork(id, POW_HASH, "ipfs://QmPoW");
 
 			const freelancerAddr = await freelancer.getAddress();
@@ -841,8 +828,7 @@ describe("TrustLedger", function () {
 
 		it("should require ETH fee pool for ERC-20 escrow dispute", async function () {
 			const id = await createERC20Contract();
-			const { v, r, s } = await signAccept(id);
-			await trustLedger.connect(freelancer).acceptContract(id, v, r, s);
+			await acceptERC20(id);
 			await trustLedger.connect(freelancer).submitProofOfWork(id, POW_HASH, "ipfs://QmPoW");
 
 			// No ETH → revert InsufficientFunds
@@ -860,8 +846,7 @@ describe("TrustLedger", function () {
 
 		it("should distribute tokens on ruling for ERC-20 escrow", async function () {
 			const id = await createERC20Contract();
-			const { v, r, s } = await signAccept(id);
-			await trustLedger.connect(freelancer).acceptContract(id, v, r, s);
+			await acceptERC20(id);
 			await trustLedger.connect(freelancer).submitProofOfWork(id, POW_HASH, "ipfs://QmPoW");
 
 			const feePool = ethers.parseEther("0.1");
@@ -875,24 +860,11 @@ describe("TrustLedger", function () {
 			expect((await token.balanceOf(freelancerAddr)) - before).to.equal(TOKEN_AMOUNT);
 		});
 
-		it("should revert createContract when ETH sent with token escrow", async function () {
+		it("should revert acceptContract when ETH sent with token escrow", async function () {
+			const id = await createERC20Contract();
+			// A token escrow is funded via transferFrom; sending ETH on accept is rejected.
 			await expect(
-				trustLedger
-					.connect(client)
-					.createContract(
-						await freelancer.getAddress(),
-						CONTRACT_HASH,
-						"ipfs://",
-						ESTIMATED_DURATION,
-						BUFFER_FACTOR,
-						ACCEPTANCE_WINDOW,
-						ARB_FEE_BPS,
-						0,
-						0,
-						await token.getAddress(),
-						TOKEN_AMOUNT,
-						{ value: ethers.parseEther("1") },
-					),
+				trustLedger.connect(client).acceptContract(id, { value: ethers.parseEther("1") }),
 			).to.be.revertedWithCustomError(trustLedger, "InvalidTokenParams");
 		});
 	});
@@ -915,7 +887,8 @@ describe("TrustLedger", function () {
 		});
 
 		it("should record usdValueAtCreation when price feed is set", async function () {
-			const id = await createContract();
+			// The USD value is locked when the client accepts and funds the escrow.
+			const id = await createAndAccept();
 			const c = await trustLedger.getContract(id);
 			// usdValueAtCreation = (1 ETH × 3000e8) / 1e18 = 3000e8 / 1e10 = 300000
 			const expected = (AMOUNT * ETH_PRICE_USD) / 10n ** 18n;
@@ -924,7 +897,7 @@ describe("TrustLedger", function () {
 
 		it("should store usdValueAtCreation = 0 when price feed returns ≤ 0", async function () {
 			await priceFeed.setPrice(0);
-			const id = await createContract();
+			const id = await createAndAccept();
 			const c = await trustLedger.getContract(id);
 			expect(c.usdValueAtCreation).to.equal(0n);
 		});
@@ -1552,9 +1525,9 @@ describe("TrustLedger", function () {
 			const tl2 = (await TLF.deploy(arb2Addr)) as unknown as TrustLedger;
 
 			const tx2 = await tl2
-				.connect(client)
-				.createContract(
-					await freelancer.getAddress(),
+				.connect(freelancer)
+				.proposeContract(
+					await client.getAddress(),
 					CONTRACT_HASH,
 					"ipfs://",
 					ESTIMATED_DURATION,
@@ -1564,8 +1537,7 @@ describe("TrustLedger", function () {
 					0,
 					0,
 					ethers.ZeroAddress,
-					0n,
-					{ value: AMOUNT },
+					AMOUNT,
 				);
 			const receipt2 = await tx2.wait();
 			const ev = receipt2?.logs
@@ -1576,12 +1548,10 @@ describe("TrustLedger", function () {
 						return null;
 					}
 				})
-				.find((e) => e?.name === "ContractCreated");
+				.find((e) => e?.name === "ContractProposed");
 			const id = ev?.args[0] as bigint;
 
-			const { v, r, s } = await signAccept(id);
-
-			await tl2.connect(freelancer).acceptContract(id, v, r, s);
+			await tl2.connect(client).acceptContract(id, { value: AMOUNT });
 			await tl2.connect(freelancer).submitProofOfWork(id, POW_HASH, "ipfs://QmPoW");
 			await tl2.connect(client).approveWork(id);
 
@@ -1616,8 +1586,7 @@ describe("TrustLedger", function () {
 			arbFeeBps?: number;
 			holdBackBps?: number;
 			warranty?: bigint;
-			tokenAmount?: bigint;
-			value?: bigint;
+			amount?: bigint;
 		}) {
 			const o = {
 				hash: CONTRACT_HASH,
@@ -1625,14 +1594,13 @@ describe("TrustLedger", function () {
 				arbFeeBps: ARB_FEE_BPS,
 				holdBackBps: 0,
 				warranty: 0n,
-				tokenAmount: 0n,
-				value: AMOUNT,
+				amount: AMOUNT,
 				...overrides,
 			};
 			return await trustLedger
-				.connect(client)
-				.createContract(
-					await freelancer.getAddress(),
+				.connect(freelancer)
+				.proposeContract(
+					await client.getAddress(),
 					o.hash,
 					o.uri,
 					ESTIMATED_DURATION,
@@ -1642,8 +1610,7 @@ describe("TrustLedger", function () {
 					o.holdBackBps,
 					o.warranty,
 					ethers.ZeroAddress,
-					o.tokenAmount,
-					{ value: o.value },
+					o.amount,
 				);
 		}
 
@@ -1699,10 +1666,10 @@ describe("TrustLedger", function () {
 			).to.be.revertedWithCustomError(trustLedger, "InvalidWarrantyPeriod");
 		});
 
-		it("should revert ETH escrow createContract when tokenAmount is non-zero", async function () {
-			await expect(createWith({ tokenAmount: 100n })).to.be.revertedWithCustomError(
+		it("should revert proposeContract with zero amount", async function () {
+			await expect(createWith({ amount: 0n })).to.be.revertedWithCustomError(
 				trustLedger,
-				"InvalidTokenParams",
+				"InsufficientFunds",
 			);
 		});
 
@@ -1736,7 +1703,7 @@ describe("TrustLedger", function () {
 	// ─── State Guards ─────────────────────────────────────────────────────────
 
 	describe("State Guards", function () {
-		it("should revert rejectContract when caller is not freelancer", async function () {
+		it("should revert rejectContract when caller is not client", async function () {
 			const id = await createContract();
 			await expect(
 				trustLedger.connect(stranger).rejectContract(id),
@@ -1746,21 +1713,21 @@ describe("TrustLedger", function () {
 		it("should revert rejectContract when status is not PENDING", async function () {
 			const id = await createAndAccept(); // ACTIVE
 			await expect(
-				trustLedger.connect(freelancer).rejectContract(id),
+				trustLedger.connect(client).rejectContract(id),
 			).to.be.revertedWithCustomError(trustLedger, "InvalidStatus");
 		});
 
-		it("should revert cancelPending when caller is not client", async function () {
+		it("should revert cancelProposal when caller is not freelancer", async function () {
 			const id = await createContract();
 			await expect(
-				trustLedger.connect(stranger).cancelPending(id),
+				trustLedger.connect(stranger).cancelProposal(id),
 			).to.be.revertedWithCustomError(trustLedger, "Unauthorized");
 		});
 
-		it("should revert cancelPending when status is not PENDING", async function () {
+		it("should revert cancelProposal when status is not PENDING", async function () {
 			const id = await createAndAccept(); // ACTIVE
 			await expect(
-				trustLedger.connect(client).cancelPending(id),
+				trustLedger.connect(freelancer).cancelProposal(id),
 			).to.be.revertedWithCustomError(trustLedger, "InvalidStatus");
 		});
 
@@ -1778,17 +1745,18 @@ describe("TrustLedger", function () {
 			).to.be.revertedWithCustomError(trustLedger, "InvalidStatus");
 		});
 
-		it("should revert acceptContract when project deadline has elapsed", async function () {
+		it("should start the project deadline only once the client accepts", async function () {
 			const id = await createContract();
-			const c = await trustLedger.getContract(id);
-			await ethers.provider.send("evm_setNextBlockTimestamp", [
-				Number(c.projectDeadline) + 1,
-			]);
-			await ethers.provider.send("evm_mine", []);
-			const { v, r, s } = await signAccept(id);
-			await expect(
-				trustLedger.connect(freelancer).acceptContract(id, v, r, s),
-			).to.be.revertedWithCustomError(trustLedger, "DeadlineElapsed");
+			// While PENDING, projectDeadline holds the relative buffered duration, not a timestamp.
+			const proposed = await trustLedger.getContract(id);
+			const expectedDuration = (ESTIMATED_DURATION * BUFFER_FACTOR) / 1000n;
+			expect(proposed.projectDeadline).to.equal(expectedDuration);
+
+			await trustLedger.connect(client).acceptContract(id, { value: AMOUNT });
+			const accepted = await trustLedger.getContract(id);
+			// After acceptance it becomes an absolute, future timestamp.
+			const nowTs = BigInt((await ethers.provider.getBlock("latest"))?.timestamp ?? 0);
+			expect(accepted.projectDeadline).to.be.gt(nowTs);
 		});
 
 		it("should revert disputeWork when caller is not client", async function () {
@@ -2020,10 +1988,10 @@ describe("TrustLedger", function () {
 	describe("Amendment Flow", function () {
 		it("should link amendment and emit ContractAmended", async function () {
 			const oldId = await createContract();
-			await trustLedger.connect(client).cancelPending(oldId);
+			await trustLedger.connect(freelancer).cancelProposal(oldId);
 			const newId = await createContract();
 
-			await expect(trustLedger.connect(client).linkAmendment(newId, oldId))
+			await expect(trustLedger.connect(freelancer).linkAmendment(newId, oldId))
 				.to.emit(trustLedger, "ContractAmended")
 				.withArgs(newId, oldId);
 
@@ -2031,9 +1999,9 @@ describe("TrustLedger", function () {
 			expect(c.previousContractId).to.equal(oldId);
 		});
 
-		it("should revert linkAmendment when caller is not client of old contract", async function () {
+		it("should revert linkAmendment when caller is not freelancer of old contract", async function () {
 			const oldId = await createContract();
-			await trustLedger.connect(client).cancelPending(oldId);
+			await trustLedger.connect(freelancer).cancelProposal(oldId);
 			const newId = await createContract();
 			await expect(
 				trustLedger.connect(stranger).linkAmendment(newId, oldId),
@@ -2044,29 +2012,29 @@ describe("TrustLedger", function () {
 			const oldId = await createContract(); // still PENDING
 			const newId = await createContract();
 			await expect(
-				trustLedger.connect(client).linkAmendment(newId, oldId),
+				trustLedger.connect(freelancer).linkAmendment(newId, oldId),
 			).to.be.revertedWithCustomError(trustLedger, "InvalidPreviousContract");
 		});
 
 		it("should revert linkAmendment when new contract is not PENDING", async function () {
 			const oldId = await createContract();
-			await trustLedger.connect(client).cancelPending(oldId);
+			await trustLedger.connect(freelancer).cancelProposal(oldId);
 			const newId = await createAndAccept(); // ACTIVE
 			await expect(
-				trustLedger.connect(client).linkAmendment(newId, oldId),
+				trustLedger.connect(freelancer).linkAmendment(newId, oldId),
 			).to.be.revertedWithCustomError(trustLedger, "InvalidStatus");
 		});
 
 		it("should revert linkAmendment when already linked", async function () {
 			const oldId = await createContract();
-			await trustLedger.connect(client).cancelPending(oldId);
+			await trustLedger.connect(freelancer).cancelProposal(oldId);
 			const newId = await createContract();
-			await trustLedger.connect(client).linkAmendment(newId, oldId);
+			await trustLedger.connect(freelancer).linkAmendment(newId, oldId);
 
 			const anotherId = await createContract();
-			await trustLedger.connect(client).cancelPending(anotherId);
+			await trustLedger.connect(freelancer).cancelProposal(anotherId);
 			await expect(
-				trustLedger.connect(client).linkAmendment(newId, anotherId),
+				trustLedger.connect(freelancer).linkAmendment(newId, anotherId),
 			).to.be.revertedWithCustomError(trustLedger, "AlreadySet");
 		});
 	});
@@ -2329,9 +2297,9 @@ describe("TrustLedger", function () {
 			await ethers.provider.send("evm_mine", []);
 
 			const tx2 = await tl2
-				.connect(client)
-				.createContract(
-					await freelancer.getAddress(),
+				.connect(freelancer)
+				.proposeContract(
+					await client.getAddress(),
 					CONTRACT_HASH,
 					"ipfs://QmC",
 					ESTIMATED_DURATION,
@@ -2341,8 +2309,7 @@ describe("TrustLedger", function () {
 					0,
 					0,
 					ethers.ZeroAddress,
-					0n,
-					{ value: AMOUNT },
+					AMOUNT,
 				);
 			const rcpt2 = await tx2.wait();
 			const cid = rcpt2?.logs
@@ -2353,10 +2320,9 @@ describe("TrustLedger", function () {
 						return null;
 					}
 				})
-				.find((e) => e?.name === "ContractCreated")?.args[0] as bigint;
+				.find((e) => e?.name === "ContractProposed")?.args[0] as bigint;
 
-			const { v, r, s } = await signAccept(cid);
-			await tl2.connect(freelancer).acceptContract(cid, v, r, s);
+			await tl2.connect(client).acceptContract(cid, { value: AMOUNT });
 			await tl2.connect(freelancer).submitProofOfWork(cid, POW_HASH, "ipfs://QmP");
 			await tl2.connect(client).disputeWork(cid);
 


### PR DESCRIPTION
## Summary

Flips the escrow handshake: the **freelancer proposes** an unfunded contract and the **client reviews and accepts-by-funding** (or rejects). The client's funding transaction is now the consent signal, so the off-chain signature scheme is removed.

## Contract changes (`TrustLedger.sol`)
- `createContract` → `proposeContract` (freelancer caller, non-payable; params `client` + `amount`)
- `acceptContract(uint256 id)` is now `payable`, client-only; requires `msg.value == amount` (ETH) or `transferFrom` (ERC-20); sets the absolute `projectDeadline` at acceptance
- `cancelPending` → `cancelProposal` (freelancer); `rejectContract` (client)
- `ContractCreated` → `ContractProposed`; removed `InvalidSignature`

## Frontend
- `/create` is now the freelancer propose page (client address/email)
- New `/client/accept` review page: decrypt-to-view, Accept & Fund, Reject
- Shared `DecryptDocumentForm` component; dashboard PENDING actions updated
- Magic-link payload carries client fields and links to `/client/accept`
- `decryptFile` now passes the bundle's stored `iter` to `deriveKey`

## Tests & docs
- Foundry: 97 passing; Hardhat: 146 passing
- Demo scripts and all affected docs updated

## Verification (local, all green)
- `forge test` (97), `forge fmt --check`, `forge lint`, `forge build`
- `npx hardhat test` (146)
- `npm run lint:frontend`, `npm run build:frontend`, `tsc --noEmit`