### PR TITLE
fix(create): decode proposeContract revert and surface missing fields

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
+set -e
 prettier --write . && git add -u
 npm run lint && npm run lint:frontend
 (cd src && npx tsc --noEmit)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,3 @@
+set -e
+npm run lint:frontend
 (cd contracts && FOUNDRY_PROFILE=ci forge build && FOUNDRY_PROFILE=ci forge test)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -785,6 +785,34 @@ privately via the contact in `SECURITY.md`.
 TrustLedger is currently pre-mainnet. No contracts hold real user funds. The
 codebase targets Ethereum Sepolia (testnet) and is under active development.
 
+### GitHub Security Alert Commands
+
+Three npm scripts surface open security alerts from GitHub without leaving the
+terminal. They require `gh` (already authenticated) and `jq`.
+
+| Command                       | Description                                                                                   |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| `npm run security`            | Runs both `security:alerts` and `security:dependabot` in sequence.                            |
+| `npm run security:alerts`     | Lists open GitHub code-scanning alerts — rule ID, severity, description, file, line, and URL. |
+| `npm run security:dependabot` | Lists open Dependabot alerts — package name, severity, advisory summary, and URL.             |
+
+**Output format** — each command returns a compact JSON array so you can pipe it
+further or review it directly:
+
+```bash
+# Review all open alerts at once
+npm run security
+
+# Pipe code-scanning alerts into a pager
+npm run security:alerts | less
+
+# Filter to critical Dependabot alerts only
+npm run security:dependabot | jq '[.[] | select(.severity == "critical")]'
+```
+
+Resolve alerts on a dedicated branch (`fix/security-...`) and open a PR so CI
+re-runs the scans and confirms the fix. See the branching guidelines above.
+
 ---
 
 ## License

--- a/docs/MISCELLANEOUS.md
+++ b/docs/MISCELLANEOUS.md
@@ -368,6 +368,20 @@ privately via the contact in `SECURITY.md`.
 TrustLedger is currently pre-mainnet. No contracts hold real user funds. The
 codebase targets Ethereum Sepolia (testnet) and is under active development.
 
+### Security Alert Commands
+
+Run these from the repo root to pull open GitHub security alerts on demand.
+Requires `gh` (authenticated) and `jq`.
+
+| Command                       | What it fetches                                                    |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `npm run security`            | All open alerts (code scanning + Dependabot)                       |
+| `npm run security:alerts`     | Open code-scanning alerts with rule, severity, file, line, and URL |
+| `npm run security:dependabot` | Open Dependabot alerts with package, severity, summary, and URL    |
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#github-security-alert-commands) for usage
+examples and the fix workflow.
+
 ---
 
 ## License

--- a/package.json
+++ b/package.json
@@ -99,7 +99,10 @@
 		"cache:clear:prettier": "find . -name '.prettiercache' -maxdepth 3 | grep -v node_modules | xargs rm -f",
 		"cache:clear:npm": "npm cache clean --force",
 		"cache:clear:hardhat": "rm -rf artifacts cache typechain-types",
-		"cache:clear:typechain": "rm -rf typechain-types"
+		"cache:clear:typechain": "rm -rf typechain-types",
+		"security:alerts": "gh api repos/kevinle3212/TrustLedger/code-scanning/alerts?state=open --paginate | jq '[.[] | {number: .number, rule: .rule.id, severity: .rule.severity, description: .rule.description, file: .most_recent_instance.location.path, line: .most_recent_instance.location.start_line, url: .html_url}]'",
+		"security:dependabot": "gh api repos/kevinle3212/TrustLedger/dependabot/alerts?state=open --paginate | jq '[.[] | {number: .number, package: .dependency.package.name, severity: .security_advisory.severity, summary: .security_advisory.summary, url: .html_url}]'",
+		"security": "npm run security:alerts && npm run security:dependabot"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^21.0.2",

--- a/src/app/create/_components/SubmitSummary.tsx
+++ b/src/app/create/_components/SubmitSummary.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { DecodedContractError } from "@/lib/contractErrors";
+
 interface Props {
 	amount: string;
 	/** Payment token type. */
@@ -8,12 +10,18 @@ interface Props {
 	bufferFactor: string;
 	holdBack: "none" | "5" | "10" | "15";
 	simError: Error | null;
+	/** Decoded custom-error details from a simulation revert. */
+	decodedSimError: DecodedContractError | null;
 	/** Simulation pipeline stage. */
 	simStatus: "idle" | "loading" | "ready";
 	writeError: Error | null;
 	/** Wallet/chain transaction lifecycle stage. */
 	txStatus: "idle" | "pending" | "confirming";
 	hasBlockingErrors: boolean;
+	/** Whether the user has attempted to submit (triggers missing-field banner). */
+	submitAttempted: boolean;
+	/** Human-readable labels of fields that still have validation errors. */
+	missingFieldLabels: string[];
 	/** Proposer's role in the contract. */
 	proposerRole: "freelancer" | "client";
 }
@@ -26,14 +34,25 @@ export function SubmitSummary({
 	bufferFactor,
 	holdBack,
 	simError,
+	decodedSimError,
 	simStatus,
 	writeError,
 	txStatus,
 	hasBlockingErrors,
+	submitAttempted,
+	missingFieldLabels,
 	proposerRole,
 }: Props): React.JSX.Element {
 	const isUsdc = token === "usdc";
 	const isClientProposing = proposerRole === "client";
+
+	/** Message to show for a simulation revert, preferring the decoded form. */
+	const simErrorMessage: string | null = (() => {
+		if (simError === null) return null;
+		if (decodedSimError !== null) return decodedSimError.message;
+		return (simError as { shortMessage?: string }).shortMessage ?? simError.message;
+	})();
+
 	return (
 		<>
 			{amount !== "" && (
@@ -75,11 +94,35 @@ export function SubmitSummary({
 				</div>
 			)}
 
-			{/* Simulation error - shown before MetaMask opens, surfaces revert reason. */}
-			{simError !== null && simStatus !== "idle" && (
-				<p className="text-red-500 dark:text-red-400 text-sm rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-3">
-					{(simError as { shortMessage?: string }).shortMessage ?? simError.message}
-				</p>
+			{/* Missing-field banner — shown after the first submit attempt. */}
+			{submitAttempted && missingFieldLabels.length > 0 && (
+				<div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
+					<p className="font-medium mb-1">Fix the following before submitting:</p>
+					<ul className="list-disc list-inside space-y-0.5">
+						{missingFieldLabels.map((label) => (
+							<li key={label} className="capitalize">
+								{label}
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+
+			{/* Simulation error — shown before MetaMask opens, surfaces revert reason. */}
+			{simErrorMessage !== null && simStatus !== "idle" && (
+				<div className="rounded-lg bg-red-500/10 border border-red-500/20 px-4 py-3 text-sm text-red-500 dark:text-red-400">
+					<p className="font-medium mb-0.5">Transaction would revert</p>
+					<p>{simErrorMessage}</p>
+					{decodedSimError?.field !== undefined && (
+						<p className="mt-1 text-xs opacity-75">
+							Check the{" "}
+							<span className="font-medium">
+								{decodedSimError.field.replace(/([A-Z])/g, " $1").trim()}
+							</span>{" "}
+							field above.
+						</p>
+					)}
+				</div>
 			)}
 
 			{writeError !== null && (

--- a/src/app/create/_components/SubmitSummary.tsx
+++ b/src/app/create/_components/SubmitSummary.tsx
@@ -47,7 +47,7 @@ export function SubmitSummary({
 	const isClientProposing = proposerRole === "client";
 
 	/** Message to show for a simulation revert, preferring the decoded form. */
-	const simErrorMessage: string | null = (() => {
+	const simErrorMessage: string | null = ((): string | null => {
 		if (simError === null) return null;
 		if (decodedSimError !== null) return decodedSimError.message;
 		return (simError as { shortMessage?: string }).shortMessage ?? simError.message;

--- a/src/app/create/_lib/useCreatePageState.ts
+++ b/src/app/create/_lib/useCreatePageState.ts
@@ -30,6 +30,7 @@ import { uploadToPinata } from "@/lib/ipfs";
 import { encryptFile } from "@/lib/encryption";
 import type { ArweaveJWK } from "@/lib/arweave";
 import { useRole } from "@/contexts/RoleContext";
+import { decodeContractError, type DecodedContractError } from "@/lib/contractErrors";
 import type { CreateState, FormFields } from "./types";
 import { createReducer } from "./reducer";
 
@@ -49,6 +50,8 @@ export function useCreatePageState(): {
 	receipt: TransactionReceipt | undefined;
 	simData: { request: unknown } | undefined;
 	simError: Error | null;
+	decodedSimError: DecodedContractError | null;
+	missingFieldLabels: string[];
 	txArgs: {
 		functionName: "proposeContractByClient" | "proposeContract";
 		address: `0x${string}`;
@@ -159,7 +162,7 @@ export function useCreatePageState(): {
 				integer: true,
 				unit: "days",
 			}),
-			arbitrationFeePct: validateNumberInRange(form.arbitrationFeePct, 0, 50),
+			arbitrationFeePct: validateNumberInRange(form.arbitrationFeePct, 0.01, 50),
 			warrantyPeriodDays:
 				form.holdBack === "none"
 					? undefined
@@ -183,6 +186,30 @@ export function useCreatePageState(): {
 	}
 
 	const hasBlockingErrors = Object.values(fieldErrors).some((e) => e !== undefined);
+
+	const FIELD_LABELS: Record<string, string> = {
+		client: "client address",
+		clientEmail: "client email",
+		amount: "escrow amount",
+		contractURI: "contract document",
+		paymentToken: "payment token",
+		estimatedDurationDays: "estimated duration",
+		bufferFactor: "buffer factor",
+		acceptanceWindowDays: "acceptance window",
+		arbitrationFeePct: "arbitration fee",
+		warrantyPeriodDays: "warranty period",
+		pinataJwt: "Pinata JWT",
+		passphrase: "passphrase",
+	};
+
+	const missingFieldLabels = useMemo(
+		() =>
+			Object.entries(fieldErrors)
+				.filter(([, v]) => v !== undefined)
+				.map(([k]) => FIELD_LABELS[k] ?? k),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[fieldErrors],
+	);
 
 	const txArgs = useMemo(() => {
 		if (
@@ -239,17 +266,18 @@ export function useCreatePageState(): {
 		abi: TRUSTLEDGER_ABI,
 		functionName: "proposeContractByClient",
 		args: clientTxArgs?.args,
-		query: { enabled: clientTxArgs !== null },
+		query: { enabled: clientTxArgs !== null && !hasBlockingErrors },
 	});
 	const { data: freelancerSimData, error: freelancerSimError } = useSimulateContract({
 		address: TRUSTLEDGER_ADDRESS,
 		abi: TRUSTLEDGER_ABI,
 		functionName: "proposeContract",
 		args: freelancerTxArgs?.args,
-		query: { enabled: freelancerTxArgs !== null },
+		query: { enabled: freelancerTxArgs !== null && !hasBlockingErrors },
 	});
 	const simData = clientSimData ?? freelancerSimData;
 	const simError = clientSimError ?? freelancerSimError;
+	const decodedSimError = decodeContractError(simError);
 
 	function handleSubmit(e: React.SyntheticEvent): void {
 		e.preventDefault();
@@ -377,6 +405,8 @@ export function useCreatePageState(): {
 		receipt,
 		simData,
 		simError,
+		decodedSimError,
+		missingFieldLabels,
 		txArgs,
 		hasBlockingErrors,
 		set,

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -22,6 +22,8 @@ export default function CreatePage(): React.JSX.Element {
 		usdcAddress,
 		simData,
 		simError,
+		decodedSimError,
+		missingFieldLabels,
 		txArgs,
 		hasBlockingErrors,
 		set,
@@ -202,6 +204,7 @@ export default function CreatePage(): React.JSX.Element {
 					bufferFactor={form.bufferFactor}
 					holdBack={form.holdBack}
 					simError={simError}
+					decodedSimError={decodedSimError}
 					simStatus={
 						txArgs === null
 							? "idle"
@@ -212,6 +215,8 @@ export default function CreatePage(): React.JSX.Element {
 					writeError={writeError}
 					txStatus={isPending ? "pending" : isConfirming ? "confirming" : "idle"}
 					hasBlockingErrors={hasBlockingErrors}
+					submitAttempted={state.submitAttempted}
+					missingFieldLabels={missingFieldLabels}
 					proposerRole={proposerRole}
 				/>
 			</form>

--- a/src/lib/contractErrors.ts
+++ b/src/lib/contractErrors.ts
@@ -1,0 +1,95 @@
+/**
+ * Maps TrustLedger custom Solidity errors to human-readable messages and the
+ * corresponding form field that caused the revert. Used to surface actionable
+ * feedback from simulation failures instead of the generic "reverted" string.
+ */
+
+export interface DecodedContractError {
+	/** Human-readable explanation of what went wrong. */
+	message: string;
+	/** Form field key that caused the revert, if applicable. */
+	field?: string;
+}
+
+const ERROR_MAP: Record<string, DecodedContractError> = {
+	ZeroAddress: {
+		message: "Client address is required.",
+		field: "client",
+	},
+	SelfContract: {
+		message: "You cannot propose a contract to yourself — use a different wallet address.",
+		field: "client",
+	},
+	InsufficientFunds: {
+		message: "Escrow amount must be greater than zero.",
+		field: "amount",
+	},
+	EmptyHash: {
+		message: "Contract document is missing — upload a file or enter a URI.",
+		field: "contractURI",
+	},
+	EmptyURI: {
+		message: "Contract document URI is required — upload a file or enter a URI.",
+		field: "contractURI",
+	},
+	InvalidBufferFactor: {
+		message: "Buffer factor must be at least 1100 (a 1.1× multiplier).",
+		field: "bufferFactor",
+	},
+	InvalidAcceptanceWindow: {
+		message: "Acceptance window must be at least 48 hours (2 days).",
+		field: "acceptanceWindowDays",
+	},
+	InvalidArbitrationFee: {
+		message: "Arbitration fee must be between 0.01% and 50%.",
+		field: "arbitrationFeePct",
+	},
+	InvalidHoldBack: {
+		message: "Hold-back percentage must be None, 5%, 10%, or 15%.",
+		field: "holdBack",
+	},
+	InvalidWarrantyPeriod: {
+		message: "Set a warranty period when a hold-back is selected, or clear both.",
+		field: "warrantyPeriodDays",
+	},
+	TokenNotAllowed: {
+		message: "This token is not supported on the current network.",
+		field: "paymentToken",
+	},
+	InvalidTokenParams: {
+		message: "Invalid payment token configuration.",
+		field: "paymentToken",
+	},
+	EnforcedPause: {
+		message: "The TrustLedger contract is currently paused — try again later.",
+	},
+};
+
+/** Pulls the Solidity error name out of a viem/wagmi revert error. */
+function extractErrorName(err: Error): string | undefined {
+	// viem ContractFunctionRevertedError exposes .data.errorName when decoded
+	const anyErr = err as unknown as Record<string, unknown>;
+	const data = anyErr["data"];
+	if (data !== null && typeof data === "object") {
+		const name = (data as Record<string, unknown>)["errorName"];
+		if (typeof name === "string") return name;
+	}
+	// Fallback: extract from the message string, e.g. "reason:\nFooBar()"
+	const match = /\b([A-Z][A-Za-z]+)\(\)/.exec(err.message);
+	return match?.[1];
+}
+
+/**
+ * Decodes a viem/wagmi simulation or write error into a structured message.
+ * Returns `null` if the error is not a known TrustLedger custom error.
+ *
+ * @example
+ *   const decoded = decodeContractError(simError);
+ *   // { message: "Client address is required.", field: "client" }
+ */
+export function decodeContractError(err: Error | null): DecodedContractError | null {
+	if (err === null) return null;
+	const name = extractErrorName(err);
+	if (name !== undefined && name in ERROR_MAP) return ERROR_MAP[name]!;
+	return null;
+}

--- a/src/lib/contractErrors.ts
+++ b/src/lib/contractErrors.ts
@@ -90,6 +90,6 @@ function extractErrorName(err: Error): string | undefined {
 export function decodeContractError(err: Error | null): DecodedContractError | null {
 	if (err === null) return null;
 	const name = extractErrorName(err);
-	if (name !== undefined && name in ERROR_MAP) return ERROR_MAP[name]!;
+	if (name !== undefined && name in ERROR_MAP) return ERROR_MAP[name] ?? null;
 	return null;
 }


### PR DESCRIPTION
- Gate simulation on !hasBlockingErrors so it never fires before the
  form is valid, eliminating the premature 'reverted' error
- Add contractErrors.ts mapping all 13 custom Solidity errors to
  human-readable messages and the responsible field key
- SubmitSummary now shows a missing-fields banner (post-submit) and a
  decoded revert block instead of the generic shortMessage
- Raise arbitrationFeePct validation min from 0 to 0.01 — the contract
  rejects arbitrationFeeBps == 0, which previously caused a silent
  submit failure
