### PR TITLE
Fix wallet menu and locale coverage

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -282,6 +282,9 @@ defined terms, numbering, links, and Markdown formatting.
 
 The frontend uses `next-intl`. Keep user-visible strings in the established
 message structure and verify locale routing before moving text into components.
+Every key in `src/messages/en.json` must exist in each supported locale file.
+Run `npm run test:frontend:unit -- locale-messages.test.ts` after adding or
+moving visible copy so missing locale equivalents fail before review.
 
 ## Styling And Motion
 

--- a/docs/WALLETS.md
+++ b/docs/WALLETS.md
@@ -34,7 +34,10 @@ it when changing Reown AppKit, supported chains, or wallet metadata.
 <!-- docs-section-nav:end -->
 
 The frontend uses Reown AppKit with wagmi and viem. Configuration lives in
-`src/lib/wagmi.ts`.
+`src/lib/wagmi.ts`. The navigation wallet control is split into a lightweight
+disconnected shell and the connected menu. Keep the connected path loaded when a
+wallet is already connected so copy-address, analytics, dashboard, and
+disconnect actions are immediately available without opening the AppKit modal.
 
 Supported frontend networks are:
 

--- a/src/app/[locale]/juror/_components/JurorPageInner.tsx
+++ b/src/app/[locale]/juror/_components/JurorPageInner.tsx
@@ -24,10 +24,15 @@ import { readEvidenceDraftHistory, type EvidenceDraftHistoryItem } from "@/store
 const MIN_STAKE_ETH = 0.01;
 
 /** Validates a juror stake amount: a positive ETH value of at least `minEth`. */
-function validateStake(value: string, minEth: number, maxEth?: number): string | undefined {
+function validateStake(
+	value: string,
+	minEth: number,
+	minimumMessage: string,
+	maxEth?: number,
+): string | undefined {
 	const base = validateEthAmount(value, maxEth);
 	if (base !== undefined) return base;
-	return Number(value) < minEth ? `Minimum is ${minEth.toString()} ETH.` : undefined;
+	return Number(value) < minEth ? minimumMessage : undefined;
 }
 
 const SEVEN_DAYS_S = 7 * 24 * 60 * 60;
@@ -206,7 +211,11 @@ function RegisterForm(): React.JSX.Element {
 	const { writeContract, data: txHash, isPending, error, reset } = useWriteContract();
 	const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
 
-	const amountError = validateStake(ethAmount, MIN_STAKE_ETH);
+	const amountError = validateStake(
+		ethAmount,
+		MIN_STAKE_ETH,
+		t("minimumEth", { amount: MIN_STAKE_ETH.toString() }),
+	);
 
 	function handleRegister(e: React.SyntheticEvent<HTMLFormElement>): void {
 		e.preventDefault();
@@ -326,8 +335,13 @@ function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.El
 	const isRegistered = juror?.active === true || (juror?.stake ?? 0n) > 0n;
 
 	const maxUnstakeEth = juror !== undefined ? Number(formatEther(juror.stake)) : undefined;
-	const addError = validateStake(addAmount, 0.001);
-	const unstakeError = validateStake(unstakeAmount, 0.001, maxUnstakeEth);
+	const addError = validateStake(addAmount, 0.001, t("minimumEth", { amount: "0.001" }));
+	const unstakeError = validateStake(
+		unstakeAmount,
+		0.001,
+		t("minimumEth", { amount: "0.001" }),
+		maxUnstakeEth,
+	);
 
 	if (!isRegistered) return <></>;
 
@@ -466,6 +480,7 @@ function ManageStakePanel({ address }: { address: `0x${string}` }): React.JSX.El
 }
 
 function OpenDisputesPanel({ address }: { address: `0x${string}` }): React.JSX.Element {
+	const t = useTranslations("Juror");
 	const locale = useLocale();
 	const { data: nextDisputeId } = useReadContract({
 		address: ARBITRATION_ADDRESS,
@@ -523,14 +538,14 @@ function OpenDisputesPanel({ address }: { address: `0x${string}` }): React.JSX.E
 	return (
 		<div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/5 p-5 flex flex-col gap-4">
 			<div>
-				<h2 className="font-semibold text-gray-900 dark:text-white">Assigned Disputes</h2>
-				<p className="text-xs text-gray-500 mt-1">
-					Recent selected juror cases from the arbitration contract.
-				</p>
+				<h2 className="font-semibold text-gray-900 dark:text-white">
+					{t("assignedDisputes")}
+				</h2>
+				<p className="text-xs text-gray-500 mt-1">{t("assignedDisputesSubtitle")}</p>
 			</div>
 			{assigned.length === 0 ? (
 				<p className="text-sm text-gray-500 dark:text-gray-400">
-					No assigned disputes found in the recent on-chain window.
+					{t("noAssignedDisputes")}
 				</p>
 			) : (
 				<div className="flex flex-col gap-3">
@@ -545,11 +560,13 @@ function OpenDisputesPanel({ address }: { address: `0x${string}` }): React.JSX.E
 								<div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
 									<div>
 										<p className="text-sm font-semibold text-gray-900 dark:text-white">
-											Dispute #{disputeId.toString()}
+											{t("disputeNumber", { id: disputeId.toString() })}
 										</p>
 										<p className="text-xs text-gray-500">
-											Contract #{dispute.contractId.toString()} ·{" "}
-											{evidenceCount.toString()} evidence items
+											{t("contractEvidenceSummary", {
+												contractId: dispute.contractId.toString(),
+												count: evidenceCount.toString(),
+											})}
 										</p>
 									</div>
 									<span className="text-xs text-gray-500">
@@ -557,15 +574,22 @@ function OpenDisputesPanel({ address }: { address: `0x${string}` }): React.JSX.E
 									</span>
 								</div>
 								<div className="tl-kv-grid text-xs">
-									<span className="text-gray-500">Fee pool</span>
+									<span className="text-gray-500">{t("feePool")}</span>
 									<span className="text-gray-900 dark:text-white">
 										{formatEther(dispute.feePool)} ETH
 									</span>
-									<span className="text-gray-500">Potential outcome</span>
+									<span className="text-gray-500">{t("potentialOutcome")}</span>
 									<span className="text-gray-900 dark:text-white">
 										{rulingReady
-											? `${formatEther(calculateLinearPayout(dispute.ruling, dispute.contractAmount))} ETH to freelancer`
-											: "Pending juror ruling"}
+											? t("freelancerPayout", {
+													amount: formatEther(
+														calculateLinearPayout(
+															dispute.ruling,
+															dispute.contractAmount,
+														),
+													),
+												})
+											: t("pendingJurorRuling")}
 									</span>
 								</div>
 								<Link
@@ -576,7 +600,7 @@ function OpenDisputesPanel({ address }: { address: `0x${string}` }): React.JSX.E
 											: "bg-gray-100 dark:bg-white/10 hover:bg-gray-200 dark:hover:bg-white/20 text-gray-900 dark:text-white"
 									}`}
 								>
-									{phaseOpen ? "Open Voting Flow" : "Review Dispute"}
+									{phaseOpen ? t("openVotingFlow") : t("reviewDispute")}
 								</Link>
 							</div>
 						);
@@ -588,6 +612,7 @@ function OpenDisputesPanel({ address }: { address: `0x${string}` }): React.JSX.E
 }
 
 function LocalDraftHistoryPanel(): React.JSX.Element {
+	const t = useTranslations("Juror");
 	const locale = useLocale();
 	const dateTimeFormatter = useMemo(
 		() => new Intl.DateTimeFormat(locale, { dateStyle: "medium", timeStyle: "short" }),
@@ -608,16 +633,12 @@ function LocalDraftHistoryPanel(): React.JSX.Element {
 		<div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/5 p-5 flex flex-col gap-4">
 			<div>
 				<h2 className="font-semibold text-gray-900 dark:text-white">
-					Local Arbitration Draft History
+					{t("localDraftHistory")}
 				</h2>
-				<p className="text-xs text-gray-500 mt-1">
-					Unsubmitted evidence drafts saved in this browser for juror and party review.
-				</p>
+				<p className="text-xs text-gray-500 mt-1">{t("localDraftHistorySubtitle")}</p>
 			</div>
 			{drafts.length === 0 ? (
-				<p className="text-sm text-gray-500 dark:text-gray-400">
-					No local arbitration drafts found on this device.
-				</p>
+				<p className="text-sm text-gray-500 dark:text-gray-400">{t("noLocalDrafts")}</p>
 			) : (
 				<div className="flex flex-col gap-3">
 					{drafts.map((draft) => (
@@ -627,25 +648,27 @@ function LocalDraftHistoryPanel(): React.JSX.Element {
 						>
 							<div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
 								<p className="text-sm font-semibold text-gray-900 dark:text-white">
-									Dispute #{draft.disputeId}
+									{t("disputeNumber", { id: draft.disputeId })}
 								</p>
 								<span className="text-xs text-gray-500">
 									{draft.updatedAt > 0
 										? dateTimeFormatter.format(new Date(draft.updatedAt))
-										: "Not Timestamped"}
+										: t("notTimestamped")}
 								</span>
 							</div>
 							<p className="mt-2 line-clamp-3 text-sm text-gray-600 dark:text-gray-300">
 								{draft.summary}
 							</p>
 							<p className="mt-2 text-xs text-gray-500">
-								Requested Completion: {draft.requestedCompletionPct.toString()}%
+								{t("requestedCompletion", {
+									percent: draft.requestedCompletionPct.toString(),
+								})}
 							</p>
 							<Link
 								href={`/arbitration/${draft.disputeId}`}
 								className="mt-3 inline-flex rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-500"
 							>
-								Open Draft Case
+								{t("openDraftCase")}
 							</Link>
 						</div>
 					))}

--- a/src/app/[locale]/legal/[slug]/page.tsx
+++ b/src/app/[locale]/legal/[slug]/page.tsx
@@ -63,15 +63,16 @@ export async function generateMetadata({
 }: {
 	params: Promise<LegalDocPageParams>;
 }): Promise<Metadata> {
-	const { slug } = await params;
+	const { locale, slug } = await params;
+	const t = await getTranslations({ locale, namespace: "Legal" });
 	const document = getLegalDocumentBySlug(slug);
 	if (document === undefined) {
-		return { title: "Legal document not found - TrustLedger" };
+		return { title: t("metadata.notFoundTitle") };
 	}
 
 	return {
-		title: `${document.title} - TrustLedger Legal Center`,
-		description: document.description,
+		title: t("metadata.documentTitle", { title: t(`documents.${document.slug}.title`) }),
+		description: t(`documents.${document.slug}.description`),
 	};
 }
 

--- a/src/app/[locale]/legal/page.tsx
+++ b/src/app/[locale]/legal/page.tsx
@@ -10,11 +10,18 @@ import {
 	resolveLegalLocale,
 } from "@/helpers/legal-docs";
 
-export const metadata: Metadata = {
-	title: "Legal Center - TrustLedger",
-	description:
-		"TrustLedger legal, policy, compliance, risk disclosure, and security document index.",
-};
+export async function generateMetadata({
+	params,
+}: {
+	params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+	const { locale } = await params;
+	const t = await getTranslations({ locale, namespace: "Legal" });
+	return {
+		title: t("metadata.title"),
+		description: t("metadata.description"),
+	};
+}
 
 export default async function LegalPage({
 	params,

--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -102,10 +102,14 @@ export function ConnectButton({ compact = false }: { compact?: boolean } = {}): 
 
 	function loadAndOpen(): void {
 		setLoadWalletUi(true);
-		setOpenOnLoadKey((value) => value + 1);
+		if (!isConnected) {
+			setOpenOnLoadKey((value) => value + 1);
+		}
 	}
 
-	if (!loadWalletUi) {
+	const shouldLoadWalletUi = loadWalletUi || (mounted && isConnected);
+
+	if (!shouldLoadWalletUi) {
 		const remembered = mounted ? getLastWallet() : null;
 		const label =
 			mounted && isConnected && address !== undefined

--- a/src/components/ConnectButtonInner.tsx
+++ b/src/components/ConnectButtonInner.tsx
@@ -169,6 +169,10 @@ export function ConnectButtonInner({
 		};
 	}, []);
 
+	function openWalletMenu(): void {
+		setWalletMenuOpen(true);
+	}
+
 	function openModal(): void {
 		void open();
 	}
@@ -212,10 +216,10 @@ export function ConnectButtonInner({
 				ref={walletMenuRef}
 				className="relative max-w-full shrink-0"
 				onPointerEnter={() => {
-					setWalletMenuOpen(true);
+					openWalletMenu();
 				}}
 				onMouseEnter={() => {
-					setWalletMenuOpen(true);
+					openWalletMenu();
 				}}
 				onPointerLeave={() => {
 					setWalletMenuOpen(false);
@@ -224,7 +228,7 @@ export function ConnectButtonInner({
 					setWalletMenuOpen(false);
 				}}
 				onFocus={() => {
-					setWalletMenuOpen(true);
+					openWalletMenu();
 				}}
 			>
 				<div className="grid max-w-full grid-cols-[minmax(0,1fr)_2.5rem] items-stretch overflow-hidden rounded-lg bg-indigo-600 text-white sm:inline-grid sm:grid-cols-[minmax(0,1fr)_2.75rem]">
@@ -257,7 +261,7 @@ export function ConnectButtonInner({
 				<div
 					role="menu"
 					aria-label={t("walletMenu")}
-					className={`absolute right-0 top-full z-50 mt-2 w-64 transition duration-150 ease-out ${menuVisibility}`}
+					className={`absolute right-0 top-full z-50 w-64 pt-2 transition duration-150 ease-out ${menuVisibility}`}
 				>
 					<div className="rounded-xl border border-gray-200 bg-white p-2 text-gray-900 shadow-lg shadow-gray-950/10 dark:border-white/10 dark:bg-gray-950 dark:text-white">
 						<Link

--- a/src/components/WalletRequiredPage.tsx
+++ b/src/components/WalletRequiredPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ConnectButton } from "@/components/ConnectButton";
+import { useTranslations } from "next-intl";
 
 function ShieldIcon(): React.JSX.Element {
 	return (
@@ -21,6 +22,8 @@ function ShieldIcon(): React.JSX.Element {
 }
 
 export function WalletRequiredPage(): React.JSX.Element {
+	const t = useTranslations("Common");
+
 	return (
 		<div className="tl-site-frame py-12 sm:py-16">
 			<section className="relative overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-950">
@@ -34,28 +37,26 @@ export function WalletRequiredPage(): React.JSX.Element {
 							<ShieldIcon />
 						</div>
 						<h1 className="mt-5 text-3xl font-semibold tracking-[-0.02em] text-gray-950 sm:text-4xl dark:text-white">
-							Wallet Connection Required
+							{t("walletRequiredTitle")}
 						</h1>
 						<p className="mt-4 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">
-							Connect your wallet to continue. TrustLedger only shows wallet-scoped
-							workspace data after your address is available in this browser.
+							{t("walletRequiredBody")}
 						</p>
 						<div className="mt-7 flex flex-col items-start gap-3">
 							<ConnectButton />
 							<p className="max-w-lg text-sm leading-6 text-gray-500 dark:text-gray-400">
-								Use the same wallet you use for contracts, juror actions,
-								reputation, and account preferences.
+								{t("walletRequiredHint")}
 							</p>
 						</div>
 					</div>
 					<div className="rounded-2xl border border-gray-200 bg-gray-50 p-5 dark:border-white/10 dark:bg-white/[0.03]">
 						<p className="text-sm font-semibold text-gray-900 dark:text-white">
-							Before You Continue
+							{t("walletRequiredChecklistTitle")}
 						</p>
 						<ul className="mt-4 grid gap-3 text-sm leading-6 text-gray-600 dark:text-gray-300">
-							<li>Confirm the wallet address before signing.</li>
-							<li>Never enter seed phrases or private keys.</li>
-							<li>Switch networks in your wallet when prompted.</li>
+							<li>{t("walletRequiredChecklistAddress")}</li>
+							<li>{t("walletRequiredChecklistSecrets")}</li>
+							<li>{t("walletRequiredChecklistNetwork")}</li>
 						</ul>
 					</div>
 				</div>

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -41,7 +41,7 @@
 		"stepDashboardTaskThree": "Use only the action buttons available to your wallet.",
 		"stepDraftTitle": "Share Secure Drafts",
 		"stepDraftBody": "Use encrypted share links or live rooms when both parties need to review contract language before deployment.",
-		"stepDraftLink": "Open Draft Editor",
+		"stepDraftLink": "فتح محرر المسودة",
 		"stepDraftTaskOne": "Create one encrypted link and send the session key separately.",
 		"stepDraftTaskTwo": "Use live sync only when both wallets are ready to co-edit.",
 		"stepDraftTaskThree": "Do not reuse older links after a newer link is generated.",
@@ -380,7 +380,25 @@
 		"addStake": "إضافة رهن",
 		"withdrawStake": "سحب الرهن",
 		"withdrawStakeMax": "سحب الرهن (حتى {amount} ETH)",
-		"unstake": "إلغاء الرهن"
+		"unstake": "إلغاء الرهن",
+		"minimumEth": "الحد الأدنى هو {amount} ETH.",
+		"assignedDisputes": "النزاعات المعيّنة",
+		"assignedDisputesSubtitle": "قضايا حديثة اختار فيها عقد التحكيم هذا المحلف.",
+		"noAssignedDisputes": "لم يتم العثور على نزاعات معيّنة في نافذة السلسلة الحديثة.",
+		"disputeNumber": "نزاع رقم {id}",
+		"contractEvidenceSummary": "عقد رقم {contractId} · {count} عنصر دليل",
+		"feePool": "مجمع الرسوم",
+		"potentialOutcome": "النتيجة المحتملة",
+		"freelancerPayout": "{amount} ETH للمستقل",
+		"pendingJurorRuling": "حكم المحلفين معلق",
+		"openVotingFlow": "فتح مسار التصويت",
+		"reviewDispute": "مراجعة النزاع",
+		"localDraftHistory": "سجل مسودات التحكيم المحلي",
+		"localDraftHistorySubtitle": "مسودات أدلة غير مرسلة محفوظة في هذا المتصفح لمراجعة المحلفين والأطراف.",
+		"noLocalDrafts": "لم يتم العثور على مسودات تحكيم محلية على هذا الجهاز.",
+		"notTimestamped": "بدون طابع زمني",
+		"requestedCompletion": "نسبة الإكمال المطلوبة: {percent}%",
+		"openDraftCase": "فتح قضية المسودة"
 	},
 	"Reputation": {
 		"title": "السمعة",
@@ -561,7 +579,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "افتح أدوات الحساب الآمنة للمحفظة والتحليلات والحالة العامة وخلفية المشروع."
+		"walletMenuHint": "افتح أدوات الحساب الآمنة للمحفظة والتحليلات والحالة العامة وخلفية المشروع.",
+		"walletRequiredTitle": "يلزم ربط المحفظة",
+		"walletRequiredBody": "اربط محفظتك للمتابعة. لا يعرض TrustLedger بيانات مساحة العمل المرتبطة بالمحفظة إلا بعد توفر عنوانك في هذا المتصفح.",
+		"walletRequiredHint": "استخدم المحفظة نفسها للعقود وإجراءات المحلفين والسمعة وتفضيلات الحساب.",
+		"walletRequiredChecklistTitle": "قبل المتابعة",
+		"walletRequiredChecklistAddress": "تأكد من عنوان المحفظة قبل التوقيع.",
+		"walletRequiredChecklistSecrets": "لا تدخل عبارات الاسترداد أو المفاتيح الخاصة أبدًا.",
+		"walletRequiredChecklistNetwork": "بدّل الشبكات في محفظتك عند مطالبتك بذلك."
 	},
 	"Decrypt": {
 		"title": "فك تشفير مستند AES-256-GCM",
@@ -706,80 +731,86 @@
 		}
 	},
 	"Legal": {
-		"eyebrow": "TrustLedger Legal Center",
-		"title": "Policies, disclosures, and compliance references",
-		"intro": "This page is the formal publication index for TrustLedger legal documents. Legal content is maintained in Markdown and can be translated with a human-review workflow before publication.",
-		"currentLocale": "Current locale:",
-		"translationStatus": "Translation status:",
+		"eyebrow": "المركز القانوني TrustLedger",
+		"title": "السياسات والإفصاحات ومراجع الامتثال",
+		"intro": "هذه الصفحة هي فهرس النشر الرسمي لمستندات TrustLedger القانونية. تتم صيانة المحتوى القانوني بصيغة Markdown ويمكن ترجمته عبر سير عمل مراجعة بشرية قبل النشر.",
+		"metadata": {
+			"title": "المركز القانوني - TrustLedger",
+			"description": "فهرس مستندات TrustLedger القانونية والسياسات والامتثال وإفصاحات المخاطر والأمان.",
+			"documentTitle": "{title} - المركز القانوني TrustLedger",
+			"notFoundTitle": "لم يتم العثور على المستند القانوني - TrustLedger"
+		},
+		"currentLocale": "اللغة الحالية:",
+		"translationStatus": "حالة الترجمة:",
 		"sourceFile": "ملف المصدر",
 		"viewDocument": "عرض المستند",
 		"status": {
-			"source": "Source",
-			"needs-review": "Needs Review",
-			"machine-assisted": "Machine Assisted"
+			"source": "المصدر",
+			"needs-review": "بحاجة إلى مراجعة",
+			"machine-assisted": "مدعوم آليًا"
 		},
 		"translationHelper": {
 			"title": "مساعد الترجمة",
-			"body": "Use this helper before publishing legal text in another language. For English, it becomes a review prompt. For other languages, it becomes a translation prompt that keeps numbering, defined terms, links, and Markdown structure intact.",
-			"stepOne": "1. Choose the legal document and target locale.",
-			"stepTwo": "2. Translate without changing obligations or remedies.",
-			"stepThree": "3. Keep the result marked needs-review until approved."
+			"body": "استخدم هذا المساعد قبل نشر نص قانوني بلغة أخرى. بالنسبة للإنجليزية يصبح طلب مراجعة. وبالنسبة للغات الأخرى يصبح طلب ترجمة يحافظ على الترقيم والمصطلحات المعرفة والروابط وبنية Markdown.",
+			"stepOne": "1. اختر المستند القانوني واللغة المستهدفة.",
+			"stepTwo": "2. ترجم دون تغيير الالتزامات أو سبل الانتصاف.",
+			"stepThree": "3. أبقِ النتيجة بعلامة بحاجة إلى مراجعة حتى تتم الموافقة."
 		},
 		"security": {
 			"title": "الأمان والإبلاغ",
-			"body": "Security disclosures remain routed through the repository security policy. Legal content changes should be reviewed before publication and mirrored into documentation.",
+			"body": "تظل إفصاحات الأمان موجهة عبر سياسة الأمان في المستودع. يجب مراجعة تغييرات المحتوى القانوني قبل النشر وعكسها في الوثائق.",
 			"viewPolicy": "عرض سياسة الأمان",
 			"readFaq": "قراءة الأسئلة الشائعة"
 		},
 		"document": {
-			"back": "Back to legal center",
-			"sourceFile": "Source file:",
-			"locale": "Locale:"
+			"back": "العودة إلى المركز القانوني",
+			"sourceFile": "ملف المصدر:",
+			"locale": "اللغة:"
 		},
 		"documents": {
 			"terms": {
-				"title": "Terms and Conditions",
-				"description": "User obligations, platform scope, wallet activity, escrow actions, and dispute handling."
+				"title": "الشروط والأحكام",
+				"description": "التزامات المستخدم ونطاق المنصة ونشاط المحفظة وإجراءات الضمان ومعالجة النزاعات."
 			},
 			"privacy": {
-				"title": "Privacy Policy",
-				"description": "Personal data handling, wallet identifiers, operational logs, analytics, and user rights."
+				"title": "سياسة الخصوصية",
+				"description": "معالجة البيانات الشخصية ومعرّفات المحافظ والسجلات التشغيلية والتحليلات وحقوق المستخدم."
 			},
 			"cookies": {
-				"title": "Cookie Policy",
-				"description": "Browser storage, cookies, analytics preferences, and consent expectations."
+				"title": "سياسة ملفات تعريف الارتباط",
+				"description": "تخزين المتصفح وملفات تعريف الارتباط وتفضيلات التحليلات وتوقعات الموافقة."
 			},
 			"acceptable-use": {
-				"title": "Acceptable Use Policy",
-				"description": "Prohibited activity, sanctions-sensitive conduct, abuse controls, and enforcement paths."
+				"title": "سياسة الاستخدام المقبول",
+				"description": "الأنشطة المحظورة والسلوك الحساس للعقوبات وضوابط إساءة الاستخدام ومسارات الإنفاذ."
 			},
 			"content": {
-				"title": "Content Policy",
-				"description": "Rules for contract links, deliverables, evidence uploads, and platform-visible materials."
+				"title": "سياسة المحتوى",
+				"description": "قواعد روابط العقود والتسليمات ورفع الأدلة والمواد المرئية على المنصة."
 			},
 			"dmca": {
-				"title": "DMCA Policy",
-				"description": "Copyright takedown notices, counter-notices, repeat infringer handling, and agent details."
+				"title": "سياسة DMCA",
+				"description": "إشعارات إزالة حقوق النشر والإشعارات المضادة ومعالجة المخالفين المتكررين وتفاصيل الوكيل."
 			},
 			"trademark": {
-				"title": "Trademark Policy",
-				"description": "Brand use, impersonation, confusing marks, and reporting requirements."
+				"title": "سياسة العلامات التجارية",
+				"description": "استخدام العلامة التجارية والانتحال والعلامات المربكة ومتطلبات الإبلاغ."
 			},
 			"risk": {
-				"title": "Risk Disclosure",
-				"description": "Blockchain, wallet, smart contract, market, arbitration, and availability risks."
+				"title": "إفصاح المخاطر",
+				"description": "مخاطر البلوكشين والمحافظ والعقود الذكية والسوق والتحكيم والتوفر."
 			},
 			"disclaimer": {
-				"title": "Disclaimer",
-				"description": "No legal, financial, tax, or investment advice and no guarantee of dispute outcomes."
+				"title": "إخلاء المسؤولية",
+				"description": "لا توجد مشورة قانونية أو مالية أو ضريبية أو استثمارية، ولا ضمان لنتائج النزاعات."
 			},
 			"community": {
-				"title": "Community Guidelines",
-				"description": "Professional conduct, evidence quality, juror behavior, and communication standards."
+				"title": "إرشادات المجتمع",
+				"description": "السلوك المهني وجودة الأدلة وسلوك المحلفين ومعايير التواصل."
 			},
 			"security": {
-				"title": "Security Policy",
-				"description": "Responsible disclosure, supported security scope, and vulnerability reporting."
+				"title": "سياسة الأمان",
+				"description": "الإفصاح المسؤول ونطاق الأمان المدعوم والإبلاغ عن الثغرات."
 			}
 		}
 	}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -413,7 +413,25 @@
 		"addStake": "Add Stake",
 		"withdrawStake": "Withdraw Stake",
 		"withdrawStakeMax": "Withdraw Stake (max {amount} ETH)",
-		"unstake": "Unstake"
+		"unstake": "Unstake",
+		"minimumEth": "Minimum is {amount} ETH.",
+		"assignedDisputes": "Assigned Disputes",
+		"assignedDisputesSubtitle": "Recent selected juror cases from the arbitration contract.",
+		"noAssignedDisputes": "No assigned disputes found in the recent on-chain window.",
+		"disputeNumber": "Dispute #{id}",
+		"contractEvidenceSummary": "Contract #{contractId} · {count} evidence items",
+		"feePool": "Fee Pool",
+		"potentialOutcome": "Potential Outcome",
+		"freelancerPayout": "{amount} ETH to freelancer",
+		"pendingJurorRuling": "Pending juror ruling",
+		"openVotingFlow": "Open Voting Flow",
+		"reviewDispute": "Review Dispute",
+		"localDraftHistory": "Local Arbitration Draft History",
+		"localDraftHistorySubtitle": "Unsubmitted evidence drafts saved in this browser for juror and party review.",
+		"noLocalDrafts": "No local arbitration drafts found on this device.",
+		"notTimestamped": "Not Timestamped",
+		"requestedCompletion": "Requested Completion: {percent}%",
+		"openDraftCase": "Open Draft Case"
 	},
 	"Reputation": {
 		"title": "Reputation",
@@ -594,7 +612,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "Open wallet-safe account tools, analytics, public status, and project background."
+		"walletMenuHint": "Open wallet-safe account tools, analytics, public status, and project background.",
+		"walletRequiredTitle": "Wallet Connection Required",
+		"walletRequiredBody": "Connect your wallet to continue. TrustLedger only shows wallet-scoped workspace data after your address is available in this browser.",
+		"walletRequiredHint": "Use the same wallet you use for contracts, juror actions, reputation, and account preferences.",
+		"walletRequiredChecklistTitle": "Before You Continue",
+		"walletRequiredChecklistAddress": "Confirm the wallet address before signing.",
+		"walletRequiredChecklistSecrets": "Never enter seed phrases or private keys.",
+		"walletRequiredChecklistNetwork": "Switch networks in your wallet when prompted."
 	},
 	"Decrypt": {
 		"title": "Decrypt AES-256-GCM document",
@@ -709,6 +734,12 @@
 		"eyebrow": "TrustLedger Legal Center",
 		"title": "Policies, disclosures, and compliance references",
 		"intro": "This page is the formal publication index for TrustLedger legal documents. Legal content is maintained in Markdown and can be translated with a human-review workflow before publication.",
+		"metadata": {
+			"title": "Legal Center - TrustLedger",
+			"description": "TrustLedger legal, policy, compliance, risk disclosure, and security document index.",
+			"documentTitle": "{title} - TrustLedger Legal Center",
+			"notFoundTitle": "Legal document not found - TrustLedger"
+		},
 		"currentLocale": "Current locale:",
 		"translationStatus": "Translation status:",
 		"sourceFile": "Source File",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -41,7 +41,7 @@
 		"stepDashboardTaskThree": "Use only the action buttons available to your wallet.",
 		"stepDraftTitle": "Share Secure Drafts",
 		"stepDraftBody": "Use encrypted share links or live rooms when both parties need to review contract language before deployment.",
-		"stepDraftLink": "Open Draft Editor",
+		"stepDraftLink": "Abrir Editor de Borrador",
 		"stepDraftTaskOne": "Create one encrypted link and send the session key separately.",
 		"stepDraftTaskTwo": "Use live sync only when both wallets are ready to co-edit.",
 		"stepDraftTaskThree": "Do not reuse older links after a newer link is generated.",
@@ -356,7 +356,7 @@
 		"ineligible": "No Elegible",
 		"notRegistered": "No Registrado",
 		"address": "Dirección",
-		"stake": "Stake",
+		"stake": "Participación",
 		"reputation": "Reputación",
 		"disputes": "Disputas",
 		"minorityVotes": "Votos Minoritarios",
@@ -380,7 +380,25 @@
 		"addStake": "Agregar Stake",
 		"withdrawStake": "Retirar Stake",
 		"withdrawStakeMax": "Retirar Stake (máx {amount} ETH)",
-		"unstake": "Deshacer Stake"
+		"unstake": "Deshacer Stake",
+		"minimumEth": "El mínimo es {amount} ETH.",
+		"assignedDisputes": "Disputas Asignadas",
+		"assignedDisputesSubtitle": "Casos recientes en los que este jurado fue seleccionado por el contrato de arbitraje.",
+		"noAssignedDisputes": "No se encontraron disputas asignadas en la ventana reciente en cadena.",
+		"disputeNumber": "Disputa #{id}",
+		"contractEvidenceSummary": "Contrato #{contractId} · {count} elementos de evidencia",
+		"feePool": "Fondo de Tarifas",
+		"potentialOutcome": "Resultado Potencial",
+		"freelancerPayout": "{amount} ETH para el freelancer",
+		"pendingJurorRuling": "Fallo del jurado pendiente",
+		"openVotingFlow": "Abrir Flujo de Votación",
+		"reviewDispute": "Revisar Disputa",
+		"localDraftHistory": "Historial Local de Borradores de Arbitraje",
+		"localDraftHistorySubtitle": "Borradores de evidencia no enviados guardados en este navegador para revisión de jurados y partes.",
+		"noLocalDrafts": "No se encontraron borradores locales de arbitraje en este dispositivo.",
+		"notTimestamped": "Sin Marca de Tiempo",
+		"requestedCompletion": "Finalización Solicitada: {percent}%",
+		"openDraftCase": "Abrir Caso Borrador"
 	},
 	"Reputation": {
 		"title": "Reputación",
@@ -561,7 +579,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "Abre herramientas seguras de cuenta, analíticas, estado público e información del proyecto."
+		"walletMenuHint": "Abre herramientas seguras de cuenta, analíticas, estado público e información del proyecto.",
+		"walletRequiredTitle": "Conexión de Billetera Requerida",
+		"walletRequiredBody": "Conecta tu billetera para continuar. TrustLedger solo muestra datos del espacio de trabajo vinculados a la billetera cuando tu dirección está disponible en este navegador.",
+		"walletRequiredHint": "Usa la misma billetera que utilizas para contratos, acciones de jurado, reputación y preferencias de cuenta.",
+		"walletRequiredChecklistTitle": "Antes de Continuar",
+		"walletRequiredChecklistAddress": "Confirma la dirección de la billetera antes de firmar.",
+		"walletRequiredChecklistSecrets": "Nunca ingreses frases semilla ni claves privadas.",
+		"walletRequiredChecklistNetwork": "Cambia de red en tu billetera cuando se te solicite."
 	},
 	"Decrypt": {
 		"title": "Descifrar documento AES-256-GCM",
@@ -709,6 +734,12 @@
 		"eyebrow": "Centro Legal de TrustLedger",
 		"title": "Políticas, divulgaciones y referencias de cumplimiento",
 		"intro": "Esta página es el índice formal de publicación de los documentos legales de TrustLedger. El contenido legal se mantiene en Markdown y puede traducirse con un flujo de revisión humana antes de publicarse.",
+		"metadata": {
+			"title": "Centro Legal - TrustLedger",
+			"description": "Índice de documentos legales, políticas, cumplimiento, divulgaciones de riesgo y seguridad de TrustLedger.",
+			"documentTitle": "{title} - Centro Legal TrustLedger",
+			"notFoundTitle": "Documento legal no encontrado - TrustLedger"
+		},
 		"currentLocale": "Idioma actual:",
 		"translationStatus": "Estado de traducción:",
 		"sourceFile": "Archivo Fuente",
@@ -738,48 +769,48 @@
 		},
 		"documents": {
 			"terms": {
-				"title": "Terms and Conditions",
-				"description": "User obligations, platform scope, wallet activity, escrow actions, and dispute handling."
+				"title": "Términos y Condiciones",
+				"description": "Obligaciones del usuario, alcance de la plataforma, actividad de billetera, acciones de escrow y manejo de disputas."
 			},
 			"privacy": {
-				"title": "Privacy Policy",
-				"description": "Personal data handling, wallet identifiers, operational logs, analytics, and user rights."
+				"title": "Política de Privacidad",
+				"description": "Tratamiento de datos personales, identificadores de billetera, registros operativos, analíticas y derechos del usuario."
 			},
 			"cookies": {
-				"title": "Cookie Policy",
-				"description": "Browser storage, cookies, analytics preferences, and consent expectations."
+				"title": "Política de Cookies",
+				"description": "Almacenamiento del navegador, cookies, preferencias de analíticas y expectativas de consentimiento."
 			},
 			"acceptable-use": {
-				"title": "Acceptable Use Policy",
-				"description": "Prohibited activity, sanctions-sensitive conduct, abuse controls, and enforcement paths."
+				"title": "Política de Uso Aceptable",
+				"description": "Actividad prohibida, conducta sensible a sanciones, controles de abuso y rutas de cumplimiento."
 			},
 			"content": {
-				"title": "Content Policy",
-				"description": "Rules for contract links, deliverables, evidence uploads, and platform-visible materials."
+				"title": "Política de Contenido",
+				"description": "Reglas para enlaces de contratos, entregables, cargas de evidencia y materiales visibles en la plataforma."
 			},
 			"dmca": {
-				"title": "DMCA Policy",
-				"description": "Copyright takedown notices, counter-notices, repeat infringer handling, and agent details."
+				"title": "Política DMCA",
+				"description": "Avisos de retirada por copyright, contranotificaciones, manejo de infractores reincidentes y datos del agente."
 			},
 			"trademark": {
-				"title": "Trademark Policy",
-				"description": "Brand use, impersonation, confusing marks, and reporting requirements."
+				"title": "Política de Marcas",
+				"description": "Uso de marca, suplantación, marcas confusas y requisitos de reporte."
 			},
 			"risk": {
-				"title": "Risk Disclosure",
-				"description": "Blockchain, wallet, smart contract, market, arbitration, and availability risks."
+				"title": "Divulgación de Riesgos",
+				"description": "Riesgos de blockchain, billetera, contratos inteligentes, mercado, arbitraje y disponibilidad."
 			},
 			"disclaimer": {
-				"title": "Disclaimer",
-				"description": "No legal, financial, tax, or investment advice and no guarantee of dispute outcomes."
+				"title": "Descargo de Responsabilidad",
+				"description": "Sin asesoría legal, financiera, fiscal o de inversión, y sin garantía de resultados de disputas."
 			},
 			"community": {
-				"title": "Community Guidelines",
-				"description": "Professional conduct, evidence quality, juror behavior, and communication standards."
+				"title": "Normas de la Comunidad",
+				"description": "Conducta profesional, calidad de evidencia, comportamiento de jurados y estándares de comunicación."
 			},
 			"security": {
-				"title": "Security Policy",
-				"description": "Responsible disclosure, supported security scope, and vulnerability reporting."
+				"title": "Política de Seguridad",
+				"description": "Divulgación responsable, alcance de seguridad admitido y reporte de vulnerabilidades."
 			}
 		}
 	}

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -41,7 +41,7 @@
 		"stepDashboardTaskThree": "Use only the action buttons available to your wallet.",
 		"stepDraftTitle": "Share Secure Drafts",
 		"stepDraftBody": "Use encrypted share links or live rooms when both parties need to review contract language before deployment.",
-		"stepDraftLink": "Open Draft Editor",
+		"stepDraftLink": "Ouvrir l’Éditeur de Brouillon",
 		"stepDraftTaskOne": "Create one encrypted link and send the session key separately.",
 		"stepDraftTaskTwo": "Use live sync only when both wallets are ready to co-edit.",
 		"stepDraftTaskThree": "Do not reuse older links after a newer link is generated.",
@@ -380,7 +380,25 @@
 		"addStake": "Ajouter de la Mise",
 		"withdrawStake": "Retirer la Mise",
 		"withdrawStakeMax": "Retirer la Mise (max {amount} ETH)",
-		"unstake": "Retirer la Mise"
+		"unstake": "Retirer la Mise",
+		"minimumEth": "Le minimum est de {amount} ETH.",
+		"assignedDisputes": "Litiges Assignés",
+		"assignedDisputesSubtitle": "Affaires récentes où ce juré a été sélectionné par le contrat d’arbitrage.",
+		"noAssignedDisputes": "Aucun litige assigné trouvé dans la fenêtre récente en chaîne.",
+		"disputeNumber": "Litige n° {id}",
+		"contractEvidenceSummary": "Contrat n° {contractId} · {count} éléments de preuve",
+		"feePool": "Réserve de Frais",
+		"potentialOutcome": "Résultat Potentiel",
+		"freelancerPayout": "{amount} ETH au freelance",
+		"pendingJurorRuling": "Décision du jury en attente",
+		"openVotingFlow": "Ouvrir le Flux de Vote",
+		"reviewDispute": "Examiner le Litige",
+		"localDraftHistory": "Historique Local des Brouillons d’Arbitrage",
+		"localDraftHistorySubtitle": "Brouillons de preuves non soumis enregistrés dans ce navigateur pour les jurés et les parties.",
+		"noLocalDrafts": "Aucun brouillon local d’arbitrage trouvé sur cet appareil.",
+		"notTimestamped": "Sans Horodatage",
+		"requestedCompletion": "Achèvement Demandé : {percent}%",
+		"openDraftCase": "Ouvrir le Cas Brouillon"
 	},
 	"Reputation": {
 		"title": "Réputation",
@@ -561,7 +579,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "Ouvrez les outils de compte sécurisés, les analyses, l’état public et le contexte du projet."
+		"walletMenuHint": "Ouvrez les outils de compte sécurisés, les analyses, l’état public et le contexte du projet.",
+		"walletRequiredTitle": "Connexion du Portefeuille Requise",
+		"walletRequiredBody": "Connectez votre portefeuille pour continuer. TrustLedger affiche uniquement les données d’espace de travail liées au portefeuille après que votre adresse est disponible dans ce navigateur.",
+		"walletRequiredHint": "Utilisez le même portefeuille que pour les contrats, les actions de juré, la réputation et les préférences de compte.",
+		"walletRequiredChecklistTitle": "Avant de Continuer",
+		"walletRequiredChecklistAddress": "Confirmez l’adresse du portefeuille avant de signer.",
+		"walletRequiredChecklistSecrets": "Ne saisissez jamais de phrase de récupération ni de clé privée.",
+		"walletRequiredChecklistNetwork": "Changez de réseau dans votre portefeuille lorsque cela est demandé."
 	},
 	"Decrypt": {
 		"title": "Déchiffrer le document AES-256-GCM",
@@ -709,12 +734,18 @@
 		"eyebrow": "Centre Juridique TrustLedger",
 		"title": "Politiques, informations et références de conformité",
 		"intro": "Cette page est l’index officiel de publication des documents juridiques TrustLedger. Le contenu juridique est maintenu en Markdown et peut être traduit avec un flux de révision humaine avant publication.",
+		"metadata": {
+			"title": "Centre Juridique - TrustLedger",
+			"description": "Index des documents juridiques, politiques, conformité, risques et sécurité de TrustLedger.",
+			"documentTitle": "{title} - Centre Juridique TrustLedger",
+			"notFoundTitle": "Document juridique introuvable - TrustLedger"
+		},
 		"currentLocale": "Langue actuelle :",
 		"translationStatus": "État de traduction :",
 		"sourceFile": "Fichier Source",
 		"viewDocument": "Voir Le Document",
 		"status": {
-			"source": "Source",
+			"source": "Origine",
 			"needs-review": "À Réviser",
 			"machine-assisted": "Assisté Par Machine"
 		},
@@ -738,48 +769,48 @@
 		},
 		"documents": {
 			"terms": {
-				"title": "Terms and Conditions",
-				"description": "User obligations, platform scope, wallet activity, escrow actions, and dispute handling."
+				"title": "Conditions Générales",
+				"description": "Obligations des utilisateurs, portée de la plateforme, activité du portefeuille, actions d’escrow et traitement des litiges."
 			},
 			"privacy": {
-				"title": "Privacy Policy",
-				"description": "Personal data handling, wallet identifiers, operational logs, analytics, and user rights."
+				"title": "Politique de Confidentialité",
+				"description": "Traitement des données personnelles, identifiants de portefeuille, journaux opérationnels, analyses et droits des utilisateurs."
 			},
 			"cookies": {
-				"title": "Cookie Policy",
-				"description": "Browser storage, cookies, analytics preferences, and consent expectations."
+				"title": "Politique de Cookies",
+				"description": "Stockage du navigateur, cookies, préférences d’analyse et attentes de consentement."
 			},
 			"acceptable-use": {
-				"title": "Acceptable Use Policy",
-				"description": "Prohibited activity, sanctions-sensitive conduct, abuse controls, and enforcement paths."
+				"title": "Politique d’Utilisation Acceptable",
+				"description": "Activités interdites, conduite sensible aux sanctions, contrôles d’abus et voies d’application."
 			},
 			"content": {
-				"title": "Content Policy",
-				"description": "Rules for contract links, deliverables, evidence uploads, and platform-visible materials."
+				"title": "Politique de Contenu",
+				"description": "Règles pour les liens de contrat, livrables, téléversements de preuves et contenus visibles sur la plateforme."
 			},
 			"dmca": {
-				"title": "DMCA Policy",
-				"description": "Copyright takedown notices, counter-notices, repeat infringer handling, and agent details."
+				"title": "Politique DMCA",
+				"description": "Avis de retrait pour droit d’auteur, contre-avis, gestion des récidivistes et coordonnées de l’agent."
 			},
 			"trademark": {
-				"title": "Trademark Policy",
-				"description": "Brand use, impersonation, confusing marks, and reporting requirements."
+				"title": "Politique de Marques",
+				"description": "Utilisation de la marque, usurpation, marques prêtant à confusion et exigences de signalement."
 			},
 			"risk": {
-				"title": "Risk Disclosure",
-				"description": "Blockchain, wallet, smart contract, market, arbitration, and availability risks."
+				"title": "Divulgation des Risques",
+				"description": "Risques liés à la blockchain, aux portefeuilles, aux contrats intelligents, au marché, à l’arbitrage et à la disponibilité."
 			},
 			"disclaimer": {
-				"title": "Disclaimer",
-				"description": "No legal, financial, tax, or investment advice and no guarantee of dispute outcomes."
+				"title": "Avertissement",
+				"description": "Aucun conseil juridique, financier, fiscal ou d’investissement, et aucune garantie sur les résultats des litiges."
 			},
 			"community": {
-				"title": "Community Guidelines",
-				"description": "Professional conduct, evidence quality, juror behavior, and communication standards."
+				"title": "Règles de la Communauté",
+				"description": "Conduite professionnelle, qualité des preuves, comportement des jurés et normes de communication."
 			},
 			"security": {
-				"title": "Security Policy",
-				"description": "Responsible disclosure, supported security scope, and vulnerability reporting."
+				"title": "Politique de Sécurité",
+				"description": "Divulgation responsable, périmètre de sécurité pris en charge et signalement des vulnérabilités."
 			}
 		}
 	}

--- a/src/messages/hi.json
+++ b/src/messages/hi.json
@@ -41,7 +41,7 @@
 		"stepDashboardTaskThree": "Use only the action buttons available to your wallet.",
 		"stepDraftTitle": "Share Secure Drafts",
 		"stepDraftBody": "Use encrypted share links or live rooms when both parties need to review contract language before deployment.",
-		"stepDraftLink": "Open Draft Editor",
+		"stepDraftLink": "ड्राफ्ट एडिटर खोलें",
 		"stepDraftTaskOne": "Create one encrypted link and send the session key separately.",
 		"stepDraftTaskTwo": "Use live sync only when both wallets are ready to co-edit.",
 		"stepDraftTaskThree": "Do not reuse older links after a newer link is generated.",
@@ -380,7 +380,25 @@
 		"addStake": "स्टेक जोड़ें",
 		"withdrawStake": "स्टेक निकालें",
 		"withdrawStakeMax": "स्टेक निकालें (अधिकतम {amount} ETH)",
-		"unstake": "अनस्टेक करें"
+		"unstake": "अनस्टेक करें",
+		"minimumEth": "न्यूनतम {amount} ETH है।",
+		"assignedDisputes": "सौंपे गए विवाद",
+		"assignedDisputesSubtitle": "हाल के मामले जिनमें इस जूरर को arbitration contract ने चुना है।",
+		"noAssignedDisputes": "हाल की on-chain विंडो में कोई सौंपा गया विवाद नहीं मिला।",
+		"disputeNumber": "विवाद #{id}",
+		"contractEvidenceSummary": "कॉन्ट्रैक्ट #{contractId} · {count} सबूत आइटम",
+		"feePool": "शुल्क पूल",
+		"potentialOutcome": "संभावित परिणाम",
+		"freelancerPayout": "फ्रीलांसर को {amount} ETH",
+		"pendingJurorRuling": "जूरर निर्णय लंबित",
+		"openVotingFlow": "वोटिंग फ्लो खोलें",
+		"reviewDispute": "विवाद देखें",
+		"localDraftHistory": "स्थानीय arbitration ड्राफ्ट इतिहास",
+		"localDraftHistorySubtitle": "जूरर और पक्षों की समीक्षा के लिए इस ब्राउज़र में सहेजे गए असबमिटेड सबूत ड्राफ्ट।",
+		"noLocalDrafts": "इस डिवाइस पर कोई स्थानीय arbitration ड्राफ्ट नहीं मिला।",
+		"notTimestamped": "समय-मुद्रित नहीं",
+		"requestedCompletion": "अनुरोधित पूर्णता: {percent}%",
+		"openDraftCase": "ड्राफ्ट केस खोलें"
 	},
 	"Reputation": {
 		"title": "प्रतिष्ठा",
@@ -561,7 +579,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "वॉलेट-सुरक्षित खाता टूल, एनालिटिक्स, सार्वजनिक स्थिति और प्रोजेक्ट पृष्ठभूमि खोलें।"
+		"walletMenuHint": "वॉलेट-सुरक्षित खाता टूल, एनालिटिक्स, सार्वजनिक स्थिति और प्रोजेक्ट पृष्ठभूमि खोलें।",
+		"walletRequiredTitle": "वॉलेट कनेक्शन आवश्यक",
+		"walletRequiredBody": "जारी रखने के लिए अपना वॉलेट कनेक्ट करें। TrustLedger इस ब्राउज़र में आपका पता उपलब्ध होने के बाद ही वॉलेट-स्कोप्ड workspace data दिखाता है।",
+		"walletRequiredHint": "कॉन्ट्रैक्ट, जूरर कार्रवाई, प्रतिष्ठा और खाते की पसंद के लिए वही वॉलेट उपयोग करें।",
+		"walletRequiredChecklistTitle": "जारी रखने से पहले",
+		"walletRequiredChecklistAddress": "साइन करने से पहले वॉलेट पता पुष्टि करें।",
+		"walletRequiredChecklistSecrets": "सीड फ़्रेज़ या निजी कुंजियाँ कभी दर्ज न करें।",
+		"walletRequiredChecklistNetwork": "कहने पर अपने वॉलेट में नेटवर्क बदलें।"
 	},
 	"Decrypt": {
 		"title": "AES-256-GCM दस्तावेज़ डिक्रिप्ट करें",
@@ -706,80 +731,86 @@
 		}
 	},
 	"Legal": {
-		"eyebrow": "TrustLedger Legal Center",
-		"title": "Policies, disclosures, and compliance references",
-		"intro": "This page is the formal publication index for TrustLedger legal documents. Legal content is maintained in Markdown and can be translated with a human-review workflow before publication.",
-		"currentLocale": "Current locale:",
-		"translationStatus": "Translation status:",
+		"eyebrow": "TrustLedger कानूनी केंद्र",
+		"title": "नीतियाँ, प्रकटीकरण और अनुपालन संदर्भ",
+		"intro": "यह पृष्ठ TrustLedger कानूनी दस्तावेज़ों का औपचारिक प्रकाशन सूचकांक है। कानूनी सामग्री Markdown में रखी जाती है और प्रकाशन से पहले मानव-समीक्षा वर्कफ़्लो से अनुवादित की जा सकती है।",
+		"metadata": {
+			"title": "कानूनी केंद्र - TrustLedger",
+			"description": "TrustLedger कानूनी, नीति, अनुपालन, जोखिम प्रकटीकरण और सुरक्षा दस्तावेज़ सूचकांक।",
+			"documentTitle": "{title} - TrustLedger कानूनी केंद्र",
+			"notFoundTitle": "कानूनी दस्तावेज़ नहीं मिला - TrustLedger"
+		},
+		"currentLocale": "वर्तमान भाषा:",
+		"translationStatus": "अनुवाद स्थिति:",
 		"sourceFile": "स्रोत फ़ाइल",
 		"viewDocument": "दस्तावेज़ देखें",
 		"status": {
-			"source": "Source",
-			"needs-review": "Needs Review",
-			"machine-assisted": "Machine Assisted"
+			"source": "स्रोत",
+			"needs-review": "समीक्षा आवश्यक",
+			"machine-assisted": "मशीन-सहायता प्राप्त"
 		},
 		"translationHelper": {
 			"title": "अनुवाद सहायक",
-			"body": "Use this helper before publishing legal text in another language. For English, it becomes a review prompt. For other languages, it becomes a translation prompt that keeps numbering, defined terms, links, and Markdown structure intact.",
-			"stepOne": "1. Choose the legal document and target locale.",
-			"stepTwo": "2. Translate without changing obligations or remedies.",
-			"stepThree": "3. Keep the result marked needs-review until approved."
+			"body": "किसी अन्य भाषा में कानूनी पाठ प्रकाशित करने से पहले इस सहायक का उपयोग करें। अंग्रेज़ी के लिए यह समीक्षा संकेत बनता है। अन्य भाषाओं के लिए यह ऐसा अनुवाद संकेत बनता है जो क्रमांकन, परिभाषित शब्द, लिंक और Markdown संरचना बनाए रखता है।",
+			"stepOne": "1. कानूनी दस्तावेज़ और लक्ष्य भाषा चुनें।",
+			"stepTwo": "2. दायित्वों या उपचारों को बदले बिना अनुवाद करें।",
+			"stepThree": "3. अनुमोदन तक परिणाम को समीक्षा आवश्यक चिह्नित रखें।"
 		},
 		"security": {
 			"title": "सुरक्षा और रिपोर्टिंग",
-			"body": "Security disclosures remain routed through the repository security policy. Legal content changes should be reviewed before publication and mirrored into documentation.",
+			"body": "सुरक्षा प्रकटीकरण repository security policy के माध्यम से ही जाते हैं। कानूनी सामग्री में बदलाव प्रकाशन से पहले समीक्षा किए जाने चाहिए और दस्तावेज़ों में भी शामिल होने चाहिए।",
 			"viewPolicy": "सुरक्षा नीति देखें",
 			"readFaq": "FAQ पढ़ें"
 		},
 		"document": {
-			"back": "Back to legal center",
-			"sourceFile": "Source file:",
-			"locale": "Locale:"
+			"back": "कानूनी केंद्र पर वापस जाएँ",
+			"sourceFile": "स्रोत फ़ाइल:",
+			"locale": "भाषा:"
 		},
 		"documents": {
 			"terms": {
-				"title": "Terms and Conditions",
-				"description": "User obligations, platform scope, wallet activity, escrow actions, and dispute handling."
+				"title": "नियम और शर्तें",
+				"description": "उपयोगकर्ता दायित्व, प्लेटफ़ॉर्म दायरा, वॉलेट गतिविधि, एस्क्रो कार्रवाई और विवाद प्रबंधन।"
 			},
 			"privacy": {
-				"title": "Privacy Policy",
-				"description": "Personal data handling, wallet identifiers, operational logs, analytics, and user rights."
+				"title": "गोपनीयता नीति",
+				"description": "व्यक्तिगत डेटा प्रबंधन, वॉलेट पहचानकर्ता, परिचालन लॉग, एनालिटिक्स और उपयोगकर्ता अधिकार।"
 			},
 			"cookies": {
-				"title": "Cookie Policy",
-				"description": "Browser storage, cookies, analytics preferences, and consent expectations."
+				"title": "कुकी नीति",
+				"description": "ब्राउज़र स्टोरेज, कुकीज़, एनालिटिक्स पसंद और सहमति अपेक्षाएँ।"
 			},
 			"acceptable-use": {
-				"title": "Acceptable Use Policy",
-				"description": "Prohibited activity, sanctions-sensitive conduct, abuse controls, and enforcement paths."
+				"title": "स्वीकार्य उपयोग नीति",
+				"description": "निषिद्ध गतिविधि, प्रतिबंध-संवेदनशील आचरण, दुरुपयोग नियंत्रण और प्रवर्तन मार्ग।"
 			},
 			"content": {
-				"title": "Content Policy",
-				"description": "Rules for contract links, deliverables, evidence uploads, and platform-visible materials."
+				"title": "सामग्री नीति",
+				"description": "कॉन्ट्रैक्ट लिंक, डिलिवरेबल्स, सबूत अपलोड और प्लेटफ़ॉर्म-दृश्य सामग्री के नियम।"
 			},
 			"dmca": {
-				"title": "DMCA Policy",
-				"description": "Copyright takedown notices, counter-notices, repeat infringer handling, and agent details."
+				"title": "DMCA नीति",
+				"description": "कॉपीराइट हटाने के नोटिस, काउंटर-नोटिस, बार-बार उल्लंघन करने वालों का प्रबंधन और एजेंट विवरण।"
 			},
 			"trademark": {
-				"title": "Trademark Policy",
-				"description": "Brand use, impersonation, confusing marks, and reporting requirements."
+				"title": "ट्रेडमार्क नीति",
+				"description": "ब्रांड उपयोग, प्रतिरूपण, भ्रमित करने वाले चिह्न और रिपोर्टिंग आवश्यकताएँ।"
 			},
 			"risk": {
-				"title": "Risk Disclosure",
-				"description": "Blockchain, wallet, smart contract, market, arbitration, and availability risks."
+				"title": "जोखिम प्रकटीकरण",
+				"description": "ब्लॉकचेन, वॉलेट, स्मार्ट कॉन्ट्रैक्ट, बाज़ार, arbitration और उपलब्धता जोखिम।"
 			},
 			"disclaimer": {
-				"title": "Disclaimer",
-				"description": "No legal, financial, tax, or investment advice and no guarantee of dispute outcomes."
+				"title": "अस्वीकरण",
+				"description": "कोई कानूनी, वित्तीय, कर या निवेश सलाह नहीं, और विवाद परिणामों की कोई गारंटी नहीं।"
 			},
 			"community": {
-				"title": "Community Guidelines",
-				"description": "Professional conduct, evidence quality, juror behavior, and communication standards."
+				"title": "समुदाय दिशानिर्देश",
+				"description": "पेशेवर आचरण, सबूत गुणवत्ता, जूरर व्यवहार और संचार मानक।"
 			},
 			"security": {
-				"title": "Security Policy",
-				"description": "Responsible disclosure, supported security scope, and vulnerability reporting."
+				"title": "सुरक्षा नीति",
+				"description": "जिम्मेदार प्रकटीकरण, समर्थित सुरक्षा दायरा और vulnerability reporting।"
 			}
 		}
 	}

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -41,7 +41,7 @@
 		"stepDashboardTaskThree": "Use only the action buttons available to your wallet.",
 		"stepDraftTitle": "Share Secure Drafts",
 		"stepDraftBody": "Use encrypted share links or live rooms when both parties need to review contract language before deployment.",
-		"stepDraftLink": "Open Draft Editor",
+		"stepDraftLink": "Abrir Editor de Rascunho",
 		"stepDraftTaskOne": "Create one encrypted link and send the session key separately.",
 		"stepDraftTaskTwo": "Use live sync only when both wallets are ready to co-edit.",
 		"stepDraftTaskThree": "Do not reuse older links after a newer link is generated.",
@@ -356,7 +356,7 @@
 		"ineligible": "Não Elegível",
 		"notRegistered": "Não Registrado",
 		"address": "Endereço",
-		"stake": "Stake",
+		"stake": "Participação",
 		"reputation": "Reputação",
 		"disputes": "Disputas",
 		"minorityVotes": "Votos Minoritários",
@@ -380,7 +380,25 @@
 		"addStake": "Adicionar Stake",
 		"withdrawStake": "Retirar Stake",
 		"withdrawStakeMax": "Retirar Stake (máx {amount} ETH)",
-		"unstake": "Remover Stake"
+		"unstake": "Remover Stake",
+		"minimumEth": "O mínimo é {amount} ETH.",
+		"assignedDisputes": "Disputas Atribuídas",
+		"assignedDisputesSubtitle": "Casos recentes em que este jurado foi selecionado pelo contrato de arbitragem.",
+		"noAssignedDisputes": "Nenhuma disputa atribuída foi encontrada na janela on-chain recente.",
+		"disputeNumber": "Disputa #{id}",
+		"contractEvidenceSummary": "Contrato #{contractId} · {count} itens de evidência",
+		"feePool": "Fundo de Taxas",
+		"potentialOutcome": "Resultado Potencial",
+		"freelancerPayout": "{amount} ETH para o freelancer",
+		"pendingJurorRuling": "Decisão do jurado pendente",
+		"openVotingFlow": "Abrir Fluxo de Votação",
+		"reviewDispute": "Revisar Disputa",
+		"localDraftHistory": "Histórico Local de Rascunhos de Arbitragem",
+		"localDraftHistorySubtitle": "Rascunhos de evidência não enviados salvos neste navegador para revisão de jurados e partes.",
+		"noLocalDrafts": "Nenhum rascunho local de arbitragem foi encontrado neste dispositivo.",
+		"notTimestamped": "Sem Registro de Tempo",
+		"requestedCompletion": "Conclusão Solicitada: {percent}%",
+		"openDraftCase": "Abrir Caso Rascunho"
 	},
 	"Reputation": {
 		"title": "Reputação",
@@ -561,7 +579,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "Abra ferramentas seguras de conta, análises, estado público e contexto do projeto."
+		"walletMenuHint": "Abra ferramentas seguras de conta, análises, estado público e contexto do projeto.",
+		"walletRequiredTitle": "Conexão de Carteira Obrigatória",
+		"walletRequiredBody": "Conecte sua carteira para continuar. O TrustLedger só mostra dados do espaço de trabalho vinculados à carteira depois que seu endereço está disponível neste navegador.",
+		"walletRequiredHint": "Use a mesma carteira usada para contratos, ações de jurado, reputação e preferências da conta.",
+		"walletRequiredChecklistTitle": "Antes de Continuar",
+		"walletRequiredChecklistAddress": "Confirme o endereço da carteira antes de assinar.",
+		"walletRequiredChecklistSecrets": "Nunca insira frases-semente ou chaves privadas.",
+		"walletRequiredChecklistNetwork": "Troque de rede na carteira quando solicitado."
 	},
 	"Decrypt": {
 		"title": "Descriptografar documento AES-256-GCM",
@@ -706,80 +731,86 @@
 		}
 	},
 	"Legal": {
-		"eyebrow": "TrustLedger Legal Center",
-		"title": "Policies, disclosures, and compliance references",
-		"intro": "This page is the formal publication index for TrustLedger legal documents. Legal content is maintained in Markdown and can be translated with a human-review workflow before publication.",
-		"currentLocale": "Current locale:",
-		"translationStatus": "Translation status:",
+		"eyebrow": "Centro Legal TrustLedger",
+		"title": "Políticas, divulgações e referências de conformidade",
+		"intro": "Esta página é o índice formal de publicação dos documentos legais da TrustLedger. O conteúdo legal é mantido em Markdown e pode ser traduzido com fluxo de revisão humana antes da publicação.",
+		"metadata": {
+			"title": "Centro Legal - TrustLedger",
+			"description": "Índice de documentos legais, políticas, conformidade, divulgações de risco e segurança da TrustLedger.",
+			"documentTitle": "{title} - Centro Legal TrustLedger",
+			"notFoundTitle": "Documento legal não encontrado - TrustLedger"
+		},
+		"currentLocale": "Idioma atual:",
+		"translationStatus": "Estado da tradução:",
 		"sourceFile": "Arquivo Fonte",
 		"viewDocument": "Ver Documento",
 		"status": {
-			"source": "Source",
-			"needs-review": "Needs Review",
-			"machine-assisted": "Machine Assisted"
+			"source": "Fonte",
+			"needs-review": "Precisa de Revisão",
+			"machine-assisted": "Assistido Por Máquina"
 		},
 		"translationHelper": {
 			"title": "Assistente De Tradução",
-			"body": "Use this helper before publishing legal text in another language. For English, it becomes a review prompt. For other languages, it becomes a translation prompt that keeps numbering, defined terms, links, and Markdown structure intact.",
-			"stepOne": "1. Choose the legal document and target locale.",
-			"stepTwo": "2. Translate without changing obligations or remedies.",
-			"stepThree": "3. Keep the result marked needs-review until approved."
+			"body": "Use este assistente antes de publicar texto legal em outro idioma. Para inglês, ele vira um pedido de revisão. Para outros idiomas, ele vira um pedido de tradução que mantém numeração, termos definidos, links e estrutura Markdown.",
+			"stepOne": "1. Escolha o documento legal e o idioma de destino.",
+			"stepTwo": "2. Traduza sem alterar obrigações ou remédios.",
+			"stepThree": "3. Mantenha o resultado marcado como precisa de revisão até ser aprovado."
 		},
 		"security": {
 			"title": "Segurança E Relatórios",
-			"body": "Security disclosures remain routed through the repository security policy. Legal content changes should be reviewed before publication and mirrored into documentation.",
+			"body": "Divulgações de segurança continuam roteadas pela política de segurança do repositório. Mudanças em conteúdo legal devem ser revisadas antes da publicação e refletidas na documentação.",
 			"viewPolicy": "Ver Política De Segurança",
 			"readFaq": "Ler Perguntas Frequentes"
 		},
 		"document": {
-			"back": "Back to legal center",
-			"sourceFile": "Source file:",
-			"locale": "Locale:"
+			"back": "Voltar ao centro legal",
+			"sourceFile": "Arquivo fonte:",
+			"locale": "Idioma:"
 		},
 		"documents": {
 			"terms": {
-				"title": "Terms and Conditions",
-				"description": "User obligations, platform scope, wallet activity, escrow actions, and dispute handling."
+				"title": "Termos e Condições",
+				"description": "Obrigações do usuário, escopo da plataforma, atividade da carteira, ações de escrow e tratamento de disputas."
 			},
 			"privacy": {
-				"title": "Privacy Policy",
-				"description": "Personal data handling, wallet identifiers, operational logs, analytics, and user rights."
+				"title": "Política de Privacidade",
+				"description": "Tratamento de dados pessoais, identificadores de carteira, logs operacionais, análises e direitos do usuário."
 			},
 			"cookies": {
-				"title": "Cookie Policy",
-				"description": "Browser storage, cookies, analytics preferences, and consent expectations."
+				"title": "Política de Cookies",
+				"description": "Armazenamento do navegador, cookies, preferências de análise e expectativas de consentimento."
 			},
 			"acceptable-use": {
-				"title": "Acceptable Use Policy",
-				"description": "Prohibited activity, sanctions-sensitive conduct, abuse controls, and enforcement paths."
+				"title": "Política de Uso Aceitável",
+				"description": "Atividades proibidas, condutas sensíveis a sanções, controles de abuso e caminhos de aplicação."
 			},
 			"content": {
-				"title": "Content Policy",
-				"description": "Rules for contract links, deliverables, evidence uploads, and platform-visible materials."
+				"title": "Política de Conteúdo",
+				"description": "Regras para links de contrato, entregáveis, uploads de evidências e materiais visíveis na plataforma."
 			},
 			"dmca": {
-				"title": "DMCA Policy",
-				"description": "Copyright takedown notices, counter-notices, repeat infringer handling, and agent details."
+				"title": "Política DMCA",
+				"description": "Avisos de remoção por direitos autorais, contranotificações, tratamento de infratores reincidentes e dados do agente."
 			},
 			"trademark": {
-				"title": "Trademark Policy",
-				"description": "Brand use, impersonation, confusing marks, and reporting requirements."
+				"title": "Política de Marcas",
+				"description": "Uso de marca, representação indevida, marcas confusas e requisitos de denúncia."
 			},
 			"risk": {
-				"title": "Risk Disclosure",
-				"description": "Blockchain, wallet, smart contract, market, arbitration, and availability risks."
+				"title": "Divulgação de Riscos",
+				"description": "Riscos de blockchain, carteira, contratos inteligentes, mercado, arbitragem e disponibilidade."
 			},
 			"disclaimer": {
-				"title": "Disclaimer",
-				"description": "No legal, financial, tax, or investment advice and no guarantee of dispute outcomes."
+				"title": "Aviso Legal",
+				"description": "Sem aconselhamento jurídico, financeiro, fiscal ou de investimento, e sem garantia de resultados de disputas."
 			},
 			"community": {
-				"title": "Community Guidelines",
-				"description": "Professional conduct, evidence quality, juror behavior, and communication standards."
+				"title": "Diretrizes da Comunidade",
+				"description": "Conduta profissional, qualidade de evidências, comportamento de jurados e padrões de comunicação."
 			},
 			"security": {
-				"title": "Security Policy",
-				"description": "Responsible disclosure, supported security scope, and vulnerability reporting."
+				"title": "Política de Segurança",
+				"description": "Divulgação responsável, escopo de segurança suportado e relatório de vulnerabilidades."
 			}
 		}
 	}

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -41,7 +41,7 @@
 		"stepDashboardTaskThree": "Use only the action buttons available to your wallet.",
 		"stepDraftTitle": "Share Secure Drafts",
 		"stepDraftBody": "Use encrypted share links or live rooms when both parties need to review contract language before deployment.",
-		"stepDraftLink": "Open Draft Editor",
+		"stepDraftLink": "Mở Trình Soạn Bản Nháp",
 		"stepDraftTaskOne": "Create one encrypted link and send the session key separately.",
 		"stepDraftTaskTwo": "Use live sync only when both wallets are ready to co-edit.",
 		"stepDraftTaskThree": "Do not reuse older links after a newer link is generated.",
@@ -380,7 +380,25 @@
 		"addStake": "Thêm Số Cược",
 		"withdrawStake": "Rút Số Cược",
 		"withdrawStakeMax": "Rút Số Cược (tối đa {amount} ETH)",
-		"unstake": "Bỏ Cược"
+		"unstake": "Bỏ Cược",
+		"minimumEth": "Tối thiểu là {amount} ETH.",
+		"assignedDisputes": "Tranh Chấp Được Giao",
+		"assignedDisputesSubtitle": "Các vụ gần đây mà thẩm phán này được hợp đồng trọng tài chọn.",
+		"noAssignedDisputes": "Không tìm thấy tranh chấp được giao trong cửa sổ on-chain gần đây.",
+		"disputeNumber": "Tranh chấp #{id}",
+		"contractEvidenceSummary": "Hợp đồng #{contractId} · {count} mục bằng chứng",
+		"feePool": "Quỹ Phí",
+		"potentialOutcome": "Kết Quả Tiềm Năng",
+		"freelancerPayout": "{amount} ETH cho freelancer",
+		"pendingJurorRuling": "Phán quyết của thẩm phán đang chờ",
+		"openVotingFlow": "Mở Luồng Bỏ Phiếu",
+		"reviewDispute": "Xem Lại Tranh Chấp",
+		"localDraftHistory": "Lịch Sử Bản Nháp Trọng Tài Cục Bộ",
+		"localDraftHistorySubtitle": "Bản nháp bằng chứng chưa gửi được lưu trong trình duyệt này để thẩm phán và các bên xem lại.",
+		"noLocalDrafts": "Không tìm thấy bản nháp trọng tài cục bộ trên thiết bị này.",
+		"notTimestamped": "Chưa Có Dấu Thời Gian",
+		"requestedCompletion": "Mức Hoàn Thành Yêu Cầu: {percent}%",
+		"openDraftCase": "Mở Vụ Bản Nháp"
 	},
 	"Reputation": {
 		"title": "Uy Tín",
@@ -561,7 +579,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "Mở công cụ tài khoản an toàn cho ví, phân tích, trạng thái công khai và thông tin dự án."
+		"walletMenuHint": "Mở công cụ tài khoản an toàn cho ví, phân tích, trạng thái công khai và thông tin dự án.",
+		"walletRequiredTitle": "Cần Kết Nối Ví",
+		"walletRequiredBody": "Kết nối ví để tiếp tục. TrustLedger chỉ hiển thị dữ liệu không gian làm việc theo ví sau khi địa chỉ của bạn có trong trình duyệt này.",
+		"walletRequiredHint": "Dùng cùng ví bạn sử dụng cho hợp đồng, hành động thẩm phán, uy tín và tùy chọn tài khoản.",
+		"walletRequiredChecklistTitle": "Trước Khi Tiếp Tục",
+		"walletRequiredChecklistAddress": "Xác nhận địa chỉ ví trước khi ký.",
+		"walletRequiredChecklistSecrets": "Không bao giờ nhập cụm từ khôi phục hoặc khóa riêng.",
+		"walletRequiredChecklistNetwork": "Chuyển mạng trong ví khi được yêu cầu."
 	},
 	"Decrypt": {
 		"title": "Giải mã tài liệu AES-256-GCM",
@@ -708,7 +733,13 @@
 	"Legal": {
 		"eyebrow": "Trung Tâm Pháp Lý TrustLedger",
 		"title": "Chính sách, công bố và tài liệu tuân thủ",
-		"intro": "This page is the formal publication index for TrustLedger legal documents. Legal content is maintained in Markdown and can be translated with a human-review workflow before publication.",
+		"intro": "Trang này là chỉ mục xuất bản chính thức cho tài liệu pháp lý của TrustLedger. Nội dung pháp lý được duy trì bằng Markdown và có thể được dịch qua quy trình rà soát của con người trước khi xuất bản.",
+		"metadata": {
+			"title": "Trung Tâm Pháp Lý - TrustLedger",
+			"description": "Chỉ mục tài liệu pháp lý, chính sách, tuân thủ, công bố rủi ro và bảo mật của TrustLedger.",
+			"documentTitle": "{title} - Trung Tâm Pháp Lý TrustLedger",
+			"notFoundTitle": "Không tìm thấy tài liệu pháp lý - TrustLedger"
+		},
 		"currentLocale": "Ngôn ngữ hiện tại:",
 		"translationStatus": "Trạng thái dịch:",
 		"sourceFile": "Tệp Nguồn",
@@ -720,7 +751,7 @@
 		},
 		"translationHelper": {
 			"title": "Trợ Lý Dịch Thuật",
-			"body": "Use this helper before publishing legal text in another language. For English, it becomes a review prompt. For other languages, it becomes a translation prompt that keeps numbering, defined terms, links, and Markdown structure intact.",
+			"body": "Dùng trợ lý này trước khi xuất bản văn bản pháp lý bằng ngôn ngữ khác. Với tiếng Anh, đây là lời nhắc rà soát. Với ngôn ngữ khác, đây là lời nhắc dịch giữ nguyên đánh số, thuật ngữ định nghĩa, liên kết và cấu trúc Markdown.",
 			"stepOne": "1. Chọn tài liệu pháp lý và ngôn ngữ đích.",
 			"stepTwo": "2. Dịch mà không thay đổi nghĩa vụ hoặc biện pháp khắc phục.",
 			"stepThree": "3. Giữ kết quả ở trạng thái cần rà soát cho đến khi được duyệt."
@@ -738,48 +769,48 @@
 		},
 		"documents": {
 			"terms": {
-				"title": "Terms and Conditions",
-				"description": "User obligations, platform scope, wallet activity, escrow actions, and dispute handling."
+				"title": "Điều Khoản và Điều Kiện",
+				"description": "Nghĩa vụ người dùng, phạm vi nền tảng, hoạt động ví, thao tác escrow và xử lý tranh chấp."
 			},
 			"privacy": {
-				"title": "Privacy Policy",
-				"description": "Personal data handling, wallet identifiers, operational logs, analytics, and user rights."
+				"title": "Chính Sách Quyền Riêng Tư",
+				"description": "Xử lý dữ liệu cá nhân, định danh ví, nhật ký vận hành, phân tích và quyền của người dùng."
 			},
 			"cookies": {
-				"title": "Cookie Policy",
-				"description": "Browser storage, cookies, analytics preferences, and consent expectations."
+				"title": "Chính Sách Cookie",
+				"description": "Lưu trữ trình duyệt, cookie, tùy chọn phân tích và kỳ vọng về đồng ý."
 			},
 			"acceptable-use": {
-				"title": "Acceptable Use Policy",
-				"description": "Prohibited activity, sanctions-sensitive conduct, abuse controls, and enforcement paths."
+				"title": "Chính Sách Sử Dụng Chấp Nhận Được",
+				"description": "Hoạt động bị cấm, hành vi nhạy cảm về trừng phạt, kiểm soát lạm dụng và hướng thực thi."
 			},
 			"content": {
-				"title": "Content Policy",
-				"description": "Rules for contract links, deliverables, evidence uploads, and platform-visible materials."
+				"title": "Chính Sách Nội Dung",
+				"description": "Quy tắc cho liên kết hợp đồng, sản phẩm bàn giao, tải bằng chứng lên và tài liệu hiển thị trên nền tảng."
 			},
 			"dmca": {
-				"title": "DMCA Policy",
-				"description": "Copyright takedown notices, counter-notices, repeat infringer handling, and agent details."
+				"title": "Chính Sách DMCA",
+				"description": "Thông báo gỡ bỏ bản quyền, phản thông báo, xử lý vi phạm lặp lại và thông tin đại diện."
 			},
 			"trademark": {
-				"title": "Trademark Policy",
-				"description": "Brand use, impersonation, confusing marks, and reporting requirements."
+				"title": "Chính Sách Nhãn Hiệu",
+				"description": "Sử dụng thương hiệu, mạo danh, nhãn hiệu gây nhầm lẫn và yêu cầu báo cáo."
 			},
 			"risk": {
-				"title": "Risk Disclosure",
-				"description": "Blockchain, wallet, smart contract, market, arbitration, and availability risks."
+				"title": "Công Bố Rủi Ro",
+				"description": "Rủi ro blockchain, ví, hợp đồng thông minh, thị trường, trọng tài và khả dụng."
 			},
 			"disclaimer": {
-				"title": "Disclaimer",
-				"description": "No legal, financial, tax, or investment advice and no guarantee of dispute outcomes."
+				"title": "Tuyên Bố Miễn Trừ",
+				"description": "Không phải tư vấn pháp lý, tài chính, thuế hoặc đầu tư, và không bảo đảm kết quả tranh chấp."
 			},
 			"community": {
-				"title": "Community Guidelines",
-				"description": "Professional conduct, evidence quality, juror behavior, and communication standards."
+				"title": "Nguyên Tắc Cộng Đồng",
+				"description": "Ứng xử chuyên nghiệp, chất lượng bằng chứng, hành vi thẩm phán và tiêu chuẩn giao tiếp."
 			},
 			"security": {
-				"title": "Security Policy",
-				"description": "Responsible disclosure, supported security scope, and vulnerability reporting."
+				"title": "Chính Sách Bảo Mật",
+				"description": "Công bố có trách nhiệm, phạm vi bảo mật được hỗ trợ và báo cáo lỗ hổng."
 			}
 		}
 	}

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -41,7 +41,7 @@
 		"stepDashboardTaskThree": "Use only the action buttons available to your wallet.",
 		"stepDraftTitle": "Share Secure Drafts",
 		"stepDraftBody": "Use encrypted share links or live rooms when both parties need to review contract language before deployment.",
-		"stepDraftLink": "Open Draft Editor",
+		"stepDraftLink": "打开草稿编辑器",
 		"stepDraftTaskOne": "Create one encrypted link and send the session key separately.",
 		"stepDraftTaskTwo": "Use live sync only when both wallets are ready to co-edit.",
 		"stepDraftTaskThree": "Do not reuse older links after a newer link is generated.",
@@ -380,7 +380,25 @@
 		"addStake": "增加质押",
 		"withdrawStake": "提取质押",
 		"withdrawStakeMax": "提取质押（最多 {amount} ETH）",
-		"unstake": "取消质押"
+		"unstake": "取消质押",
+		"minimumEth": "最低为 {amount} ETH。",
+		"assignedDisputes": "已分配争议",
+		"assignedDisputesSubtitle": "仲裁合约最近选择此陪审员参与的案件。",
+		"noAssignedDisputes": "最近的链上窗口中未找到已分配争议。",
+		"disputeNumber": "争议 #{id}",
+		"contractEvidenceSummary": "合约 #{contractId} · {count} 项证据",
+		"feePool": "费用池",
+		"potentialOutcome": "潜在结果",
+		"freelancerPayout": "{amount} ETH 给自由职业者",
+		"pendingJurorRuling": "等待陪审员裁决",
+		"openVotingFlow": "打开投票流程",
+		"reviewDispute": "查看争议",
+		"localDraftHistory": "本地仲裁草稿历史",
+		"localDraftHistorySubtitle": "此浏览器中保存的未提交证据草稿，供陪审员和当事人查看。",
+		"noLocalDrafts": "此设备上未找到本地仲裁草稿。",
+		"notTimestamped": "未加时间戳",
+		"requestedCompletion": "请求完成度：{percent}%",
+		"openDraftCase": "打开草稿案件"
 	},
 	"Reputation": {
 		"title": "信誉",
@@ -561,7 +579,14 @@
 		"account": "Account",
 		"status": "Status",
 		"about": "About",
-		"walletMenuHint": "打开钱包安全账户工具、分析、公开状态和项目背景。"
+		"walletMenuHint": "打开钱包安全账户工具、分析、公开状态和项目背景。",
+		"walletRequiredTitle": "需要连接钱包",
+		"walletRequiredBody": "请连接钱包以继续。只有当您的地址在此浏览器中可用后，TrustLedger 才会显示与钱包相关的工作区数据。",
+		"walletRequiredHint": "请使用同一个钱包处理合约、陪审员操作、信誉和账户偏好。",
+		"walletRequiredChecklistTitle": "继续之前",
+		"walletRequiredChecklistAddress": "签名前确认钱包地址。",
+		"walletRequiredChecklistSecrets": "切勿输入助记词或私钥。",
+		"walletRequiredChecklistNetwork": "按提示在钱包中切换网络。"
 	},
 	"Decrypt": {
 		"title": "解密 AES-256-GCM 文档",
@@ -706,80 +731,86 @@
 		}
 	},
 	"Legal": {
-		"eyebrow": "TrustLedger Legal Center",
-		"title": "Policies, disclosures, and compliance references",
-		"intro": "This page is the formal publication index for TrustLedger legal documents. Legal content is maintained in Markdown and can be translated with a human-review workflow before publication.",
-		"currentLocale": "Current locale:",
-		"translationStatus": "Translation status:",
+		"eyebrow": "TrustLedger 法律中心",
+		"title": "政策、披露和合规参考",
+		"intro": "本页是 TrustLedger 法律文档的正式发布索引。法律内容以 Markdown 维护，并可在发布前通过人工审核流程进行翻译。",
+		"metadata": {
+			"title": "法律中心 - TrustLedger",
+			"description": "TrustLedger 法律、政策、合规、风险披露和安全文档索引。",
+			"documentTitle": "{title} - TrustLedger 法律中心",
+			"notFoundTitle": "未找到法律文档 - TrustLedger"
+		},
+		"currentLocale": "当前语言：",
+		"translationStatus": "翻译状态：",
 		"sourceFile": "源文件",
 		"viewDocument": "查看文档",
 		"status": {
-			"source": "Source",
-			"needs-review": "Needs Review",
-			"machine-assisted": "Machine Assisted"
+			"source": "源文",
+			"needs-review": "需要审核",
+			"machine-assisted": "机器辅助"
 		},
 		"translationHelper": {
 			"title": "翻译助手",
-			"body": "Use this helper before publishing legal text in another language. For English, it becomes a review prompt. For other languages, it becomes a translation prompt that keeps numbering, defined terms, links, and Markdown structure intact.",
-			"stepOne": "1. Choose the legal document and target locale.",
-			"stepTwo": "2. Translate without changing obligations or remedies.",
-			"stepThree": "3. Keep the result marked needs-review until approved."
+			"body": "在以其他语言发布法律文本前使用此助手。对于英语，它会生成审核提示；对于其他语言，它会生成保留编号、定义术语、链接和 Markdown 结构的翻译提示。",
+			"stepOne": "1. 选择法律文档和目标语言。",
+			"stepTwo": "2. 翻译时不得改变义务或救济。",
+			"stepThree": "3. 在批准前保持需要审核状态。"
 		},
 		"security": {
 			"title": "安全与报告",
-			"body": "Security disclosures remain routed through the repository security policy. Legal content changes should be reviewed before publication and mirrored into documentation.",
+			"body": "安全披露仍通过仓库安全政策处理。法律内容变更应在发布前审核，并同步到文档中。",
 			"viewPolicy": "查看安全政策",
 			"readFaq": "阅读 FAQ"
 		},
 		"document": {
-			"back": "Back to legal center",
-			"sourceFile": "Source file:",
-			"locale": "Locale:"
+			"back": "返回法律中心",
+			"sourceFile": "源文件：",
+			"locale": "语言："
 		},
 		"documents": {
 			"terms": {
-				"title": "Terms and Conditions",
-				"description": "User obligations, platform scope, wallet activity, escrow actions, and dispute handling."
+				"title": "条款和条件",
+				"description": "用户义务、平台范围、钱包活动、托管操作和争议处理。"
 			},
 			"privacy": {
-				"title": "Privacy Policy",
-				"description": "Personal data handling, wallet identifiers, operational logs, analytics, and user rights."
+				"title": "隐私政策",
+				"description": "个人数据处理、钱包标识符、运营日志、分析和用户权利。"
 			},
 			"cookies": {
-				"title": "Cookie Policy",
-				"description": "Browser storage, cookies, analytics preferences, and consent expectations."
+				"title": "Cookie 政策",
+				"description": "浏览器存储、Cookie、分析偏好和同意预期。"
 			},
 			"acceptable-use": {
-				"title": "Acceptable Use Policy",
-				"description": "Prohibited activity, sanctions-sensitive conduct, abuse controls, and enforcement paths."
+				"title": "可接受使用政策",
+				"description": "禁止活动、制裁敏感行为、滥用控制和执行路径。"
 			},
 			"content": {
-				"title": "Content Policy",
-				"description": "Rules for contract links, deliverables, evidence uploads, and platform-visible materials."
+				"title": "内容政策",
+				"description": "合约链接、交付物、证据上传和平台可见材料的规则。"
 			},
 			"dmca": {
-				"title": "DMCA Policy",
-				"description": "Copyright takedown notices, counter-notices, repeat infringer handling, and agent details."
+				"title": "DMCA 政策",
+				"description": "版权删除通知、反通知、重复侵权者处理和代理信息。"
 			},
 			"trademark": {
-				"title": "Trademark Policy",
-				"description": "Brand use, impersonation, confusing marks, and reporting requirements."
+				"title": "商标政策",
+				"description": "品牌使用、冒充、混淆性标志和举报要求。"
 			},
 			"risk": {
-				"title": "Risk Disclosure",
-				"description": "Blockchain, wallet, smart contract, market, arbitration, and availability risks."
+				"title": "风险披露",
+				"description": "区块链、钱包、智能合约、市场、仲裁和可用性风险。"
 			},
 			"disclaimer": {
-				"title": "Disclaimer",
-				"description": "No legal, financial, tax, or investment advice and no guarantee of dispute outcomes."
+				"title": "免责声明",
+				"description": "不提供法律、财务、税务或投资建议，也不保证争议结果。"
 			},
 			"community": {
-				"title": "Community Guidelines",
-				"description": "Professional conduct, evidence quality, juror behavior, and communication standards."
+				"title": "社区准则",
+				"description": "专业行为、证据质量、陪审员行为和沟通标准。"
 			},
 			"security": {
-				"title": "Security Policy",
-				"description": "Responsible disclosure, supported security scope, and vulnerability reporting."
+				"title": "安全政策",
+				"description": "负责任披露、支持的安全范围和漏洞报告。"
 			}
 		}
 	}

--- a/src/tests/unit/connect-button-inner.test.tsx
+++ b/src/tests/unit/connect-button-inner.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 
 import { ConnectButtonInner } from "@/components/ConnectButtonInner";
 
 const openMock = jest.fn();
+const writeTextMock = jest.fn<Promise<void>, [string]>();
 
 jest.mock("@/lib/appkit", () => ({
 	ensureAppKit: jest.fn(),
@@ -67,7 +68,18 @@ jest.mock("next-intl", () => ({
 
 describe("ConnectButtonInner", () => {
 	beforeEach(() => {
+		jest.useFakeTimers();
 		openMock.mockClear();
+		writeTextMock.mockResolvedValue(undefined);
+		Object.assign(navigator, {
+			clipboard: {
+				writeText: writeTextMock,
+			},
+		});
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
 	});
 
 	it("opens a connected wallet navigation menu and keeps wallet management separate", () => {
@@ -98,5 +110,28 @@ describe("ConnectButtonInner", () => {
 		fireEvent.click(screen.getByRole("menuitem", { name: /manage wallet/i }));
 
 		expect(openMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("opens on hover and keeps the copy address button available", async () => {
+		render(<ConnectButtonInner />);
+
+		const addressButton = screen.getByRole("button", {
+			name: /connected as 0x1111111111111111111111111111111111111111/i,
+		});
+		const copyButton = screen.getByRole("button", { name: "Copy wallet address" });
+		const menu = screen.getByRole("menu", { name: "Wallet Menu" });
+
+		fireEvent.pointerEnter(addressButton);
+		expect(menu).toHaveClass("opacity-100");
+
+		fireEvent.click(copyButton);
+
+		expect(writeTextMock).toHaveBeenCalledWith("0x1111111111111111111111111111111111111111");
+		expect(await screen.findByRole("button", { name: "Address copied" })).toBeInTheDocument();
+
+		act(() => {
+			jest.advanceTimersByTime(1500);
+		});
+		expect(screen.getByRole("button", { name: "Copy wallet address" })).toBeInTheDocument();
 	});
 });

--- a/src/tests/unit/locale-messages.test.ts
+++ b/src/tests/unit/locale-messages.test.ts
@@ -1,0 +1,41 @@
+import arMessages from "@/messages/ar.json";
+import enMessages from "@/messages/en.json";
+import esMessages from "@/messages/es.json";
+import frMessages from "@/messages/fr.json";
+import hiMessages from "@/messages/hi.json";
+import ptMessages from "@/messages/pt.json";
+import viMessages from "@/messages/vi.json";
+import zhCnMessages from "@/messages/zh-CN.json";
+
+type MessageTree = Record<string, unknown>;
+
+const localizedMessages = {
+	"ar": arMessages,
+	"es": esMessages,
+	"fr": frMessages,
+	"hi": hiMessages,
+	"pt": ptMessages,
+	"vi": viMessages,
+	"zh-CN": zhCnMessages,
+} satisfies Record<string, MessageTree>;
+
+function flattenMessageKeys(tree: MessageTree, prefix = ""): string[] {
+	return Object.entries(tree).flatMap(([key, value]) => {
+		const nextPrefix = prefix === "" ? key : `${prefix}.${key}`;
+		if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+			return flattenMessageKeys(value as MessageTree, nextPrefix);
+		}
+		return [nextPrefix];
+	});
+}
+
+describe("locale message files", () => {
+	it("keep every non-English locale structurally equivalent to English", () => {
+		const englishKeys = flattenMessageKeys(enMessages).sort();
+
+		for (const messages of Object.values(localizedMessages)) {
+			const localeKeys = flattenMessageKeys(messages).sort();
+			expect(localeKeys).toEqual(englishKeys);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- localize Juror, Legal metadata, and wallet-required copy across supported locales
- keep the connected wallet menu loaded so copy, dashboard, analytics, and disconnect stay available without opening AppKit
- add locale key-parity coverage and document the wallet/i18n guardrails

## Validation
- npm run quality
- npm run build:frontend
- npm run docs:build
- npm run docs:links
- npm run doctor
- npm run test:e2e
- pre-push full gate including fork contracts, Rust, Solana, frontend E2E, and React Doctor