### PR TITLE
feat: add github analytics and timeout safeguards

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -32,6 +32,16 @@ Read root `AGENTS.md` first. This file only adds Codex-specific behavior.
   frontend from `src/` with `rtk npm run dev:frontend`; if sandboxed binding
   blocks the check, rerun that command with escalation using the user's
   repository-level pre-authorization for localhost browser validation.
+- Prefer the Codex in-app Browser plugin for localhost checks. If `iab` cannot
+  be acquired, do not stop the investigation: fall back to the installed
+  Playwright package, request escalation for the local Chromium process when
+  sandboxing blocks launch, and report the fallback explicitly.
+- Keep working clones outside iCloud-synced locations such as `~/Desktop`,
+  `~/Documents`, and `~/Library/Mobile Documents`. Preferred local roots are
+  `~/Development`, `~/Projects`, `~/Code`, and `~/Workspace`.
+- Keep external fetches and RPC transports bounded by explicit timeouts. New
+  provider integrations should reuse `src/lib/fetchTimeout.ts` or an equivalent
+  provider-native timeout so UI loading states cannot wait indefinitely.
 - Prefer targeted checks before broad gates, and check for duplicate
   build/dev/doctor processes when commands appear stuck.
 - Secret scanning: `npm run secrets:check` requires `gitleaks` and scans git

--- a/.env.example
+++ b/.env.example
@@ -332,10 +332,16 @@ ORACLE_RATE_TTL_MS=
 
 # ─── Source code link [OPTIONAL] ─────────────────────────────────────────────
 # NEXT_PUBLIC_GITHUB_URL - link to the source code repository shown in the navbar.
+#   Also powers the public GitHub stats section on /status, but only when GitHub
+#   reports the repository as public.
 #   On Vercel this is constructed automatically from the VERCEL_GIT_REPO_OWNER and
 #   VERCEL_GIT_REPO_SLUG system env vars - no manual config needed there.
 #   Set this only for local development or non-Vercel deployments.
 NEXT_PUBLIC_GITHUB_URL=
+
+# GITHUB_TOKEN - optional server-only token for higher GitHub API rate limits.
+#   The public stats endpoint still hides private repositories even with a token.
+GITHUB_TOKEN=
 
 # ─── Frontend contract addresses [REQUIRED for deployed frontend reads] ───────
 # Public deployed contract addresses and deploy blocks used by src/lib/wagmi.ts.

--- a/.env.local.example
+++ b/.env.local.example
@@ -68,9 +68,14 @@ NEXT_PUBLIC_APP_URL=
 #   pairing. Optional; falls back to NEXT_PUBLIC_APP_URL, then the live origin.
 NEXT_PUBLIC_SITE_URL=
 #
-# NEXT_PUBLIC_GITHUB_URL — source repo link shown in the navbar.
+# NEXT_PUBLIC_GITHUB_URL — source repo link shown in the navbar and public
+#   GitHub stats source for /status when the repository is public.
 #   On Vercel this is built from VERCEL_GIT_REPO_OWNER / VERCEL_GIT_REPO_SLUG.
 NEXT_PUBLIC_GITHUB_URL=
+
+# Optional server-only token for higher GitHub API rate limits. Private repos
+# remain hidden from public analytics even when this token can access them.
+GITHUB_TOKEN=
 
 # ─── Solana native-program support [REQUIRED for SOL custody] ───────────────
 # Public cluster/program configuration. Program IDs are public Solana account

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,17 @@ commands with `rtk` when available.
   the frontend from `src/` with `rtk npm run dev:frontend`; if sandboxed server
   binding blocks the check, rerun the same command with escalation and state
   that the user pre-authorized localhost browser validation for this repository.
+- Prefer the Codex in-app Browser plugin for localhost UI checks. If `iab`
+  cannot be acquired, fall back to the installed Playwright package, request
+  escalation for Chromium when sandboxing blocks launch, and document that
+  fallback in the run notes or final report.
+- Keep working clones outside iCloud-synced locations such as `~/Desktop`,
+  `~/Documents`, and `~/Library/Mobile Documents`; prefer `~/Development`,
+  `~/Projects`, `~/Code`, or `~/Workspace` so file watchers, Next.js, Turbopack,
+  TypeScript, and `node_modules` operations are not competing with cloud sync.
+- Keep external fetches and RPC transports bounded by explicit timeouts. New
+  provider integrations should reuse `src/lib/fetchTimeout.ts` or an equivalent
+  provider-native timeout so UI loading states cannot wait indefinitely.
 - SWC cache/policy work: use `src/.agents/skills/swc-config/SKILL.md`, keep
   generated native binaries ignored, and run `npm run swc:populate` before
   frontend builds or push-time checks.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,17 @@ SECURITY.md                        Vulnerability disclosure and supported scope.
 
 ### Install
 
+Keep local clones outside cloud-synced folders. On macOS, avoid `~/Desktop`,
+`~/Documents`, and `~/Library/Mobile Documents` because iCloud file sync and
+Spotlight indexing can slow Next.js file watching, Turbopack rebuilds,
+TypeScript, and large `node_modules` operations. Prefer:
+
+```bash
+mkdir -p "$HOME/Development"
+git clone git@github.com:kevinle3212/TrustLedger.git "$HOME/Development/TrustLedger"
+cd "$HOME/Development/TrustLedger"
+```
+
 ```bash
 bash tools/setup.sh
 ```
@@ -344,6 +355,10 @@ npm install
 | Build frontend            | `npm run build:frontend`         |
 | Run frontend unit tests   | `npm run test:frontend:unit`     |
 | Run React Doctor          | `cd src && npm run doctor`       |
+
+Local UI profiling prefers the Codex in-app browser when available. If the
+browser surface cannot be acquired, run the installed Playwright package against
+`http://127.0.0.1:3000` after starting `cd src && npm run dev:frontend`.
 
 ## Environment Configuration
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -62,6 +62,9 @@ configuration surfaces kept current:
 | Email provider dashboard          | Magic links and lifecycle notifications      | Verify sender domain, SPF/DKIM/DMARC, suppression handling, rate limits, and provider API keys.                                                                                                               |
 | WalletConnect/Reown dashboard     | Wallet modal relay                           | Create and configure `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` for the production domain.                                                                                                                        |
 | IPFS / storage provider           | Contract files and proof uploads             | Configure Pinata or the selected provider, review token scope, and rotate any exposed upload token.                                                                                                           |
+| Request timeout policy            | UI responsiveness and API reliability        | Keep external fetches and RPC transports bounded through `src/lib/fetchTimeout.ts` and explicit viem `http()` timeouts. Do not add provider calls that can wait indefinitely.                                 |
+| Local repository location         | File watching, rebuilds, and local tooling   | Keep working clones outside `~/Desktop`, `~/Documents`, iCloud Drive, Dropbox, OneDrive, Google Drive, Box Drive, network shares, and external drives. Prefer `~/Development/TrustLedger`.                    |
+| Browser automation fallback       | UI validation and performance profiling      | Prefer the Codex in-app browser when available. If `iab` cannot be acquired, use installed Playwright with explicit user approval for the local Chromium process and document that fallback in the run notes. |
 | Monitoring provider               | Production operations                        | Configure uptime, logs, alert routing, cost/error dashboards, and health-check bearer tokens.                                                                                                                 |
 | Docker and Kubernetes             | Container deploys                            | Set `k8s/configmap.yaml`, generate ignored `k8s/secret.yaml`, build images, and run Docker storage checks after heavy sessions.                                                                               |
 | External audit package            | Mainnet readiness                            | Provide auditor scope, engagement details, final report, accepted/rejected findings, and remediation evidence before mainnet.                                                                                 |
@@ -70,6 +73,13 @@ When a new package script depends on external state, update this table and the
 owning docs in the same change. For example, scripts that call `gh api` must
 document the required GitHub CLI authentication and permissions here, not only
 inside `package.json`.
+
+TrustLedger request paths must fail closed and visibly: RPC reads, AI summaries,
+oracle prices, email providers, IPFS uploads, and collaboration relay calls use
+short explicit timeouts. When adding a new provider integration, route it
+through the shared timeout helper or an equivalent provider-native timeout and
+return a structured error instead of leaving the browser in a permanent loading
+state.
 
 ## Root Deployment And Test Variables
 
@@ -116,16 +126,16 @@ inside `package.json`.
 These variables are safe to expose to the browser because their names start with
 `NEXT_PUBLIC_`. Do not put private keys or bearer tokens in them.
 
-| Variable                               | Required For                        | Consumed By                    |
-| -------------------------------------- | ----------------------------------- | ------------------------------ |
-| `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` | WalletConnect relay wallets         | `src/lib/wagmi.ts`             |
-| `NEXT_PUBLIC_SITE_URL`                 | Wallet metadata origin fallback     | `src/lib/wagmi.ts`             |
-| `NEXT_PUBLIC_APP_URL`                  | Magic links and wallet origin alias | API routes, `src/lib/wagmi.ts` |
-| `NEXT_PUBLIC_GITHUB_URL`               | Navbar source link                  | Frontend components            |
-| `NEXT_PUBLIC_PINATA_JWT`               | IPFS uploads                        | Frontend upload code           |
-| `NEXT_PUBLIC_SOLANA_CLUSTER`           | Native Solana support label         | `src/helpers/solana.ts`        |
-| `NEXT_PUBLIC_SOLANA_PROGRAM_ID`        | SOL escrow submission               | `src/lib/solanaEscrow.ts`      |
-| `NEXT_BASE_PATH`                       | Hosting under a subpath             | `src/next.config.ts`           |
+| Variable                               | Required For                                          | Consumed By                                  |
+| -------------------------------------- | ----------------------------------------------------- | -------------------------------------------- |
+| `NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID` | WalletConnect relay wallets                           | `src/lib/wagmi.ts`                           |
+| `NEXT_PUBLIC_SITE_URL`                 | Wallet metadata origin fallback                       | `src/lib/wagmi.ts`                           |
+| `NEXT_PUBLIC_APP_URL`                  | Magic links and wallet origin alias                   | API routes, `src/lib/wagmi.ts`               |
+| `NEXT_PUBLIC_GITHUB_URL`               | Navbar source link and public GitHub analytics source | Frontend components, `/api/analytics/github` |
+| `NEXT_PUBLIC_PINATA_JWT`               | IPFS uploads                                          | Frontend upload code                         |
+| `NEXT_PUBLIC_SOLANA_CLUSTER`           | Native Solana support label                           | `src/helpers/solana.ts`                      |
+| `NEXT_PUBLIC_SOLANA_PROGRAM_ID`        | SOL escrow submission                                 | `src/lib/solanaEscrow.ts`                    |
+| `NEXT_BASE_PATH`                       | Hosting under a subpath                               | `src/next.config.ts`                         |
 
 ## Frontend Contract Variables
 
@@ -232,6 +242,14 @@ operator alert routing are ready. The server endpoint honors Do Not Track and
 Global Privacy Control, strips query strings, and does not store wallet
 addresses, raw IP addresses, raw user agents, emails, documents, session keys,
 or private wallet material.
+
+Set `NEXT_PUBLIC_GITHUB_URL` to a public GitHub repository URL when the public
+status page should show repository activity. `/api/analytics/github` verifies
+the GitHub repository is public before returning commit, pull request, language,
+star, fork, and code-change totals. If GitHub reports the repository as private,
+missing, or inaccessible, the public status page omits the GitHub section
+entirely. `GITHUB_TOKEN` is optional and server-only; use it only to raise
+GitHub API rate limits for public metadata reads.
 
 ## Admin And Health Variables
 

--- a/src/.env.local.example
+++ b/src/.env.local.example
@@ -26,6 +26,10 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_GITHUB_URL=
 
+# Optional server-only token for higher GitHub API rate limits. Private repos
+# remain hidden from public analytics even when this token can access them.
+GITHUB_TOKEN=
+
 # Optional public Solana cluster label for native-program support. Allowed:
 # devnet, testnet, mainnet-beta, localnet. Defaults to devnet when unset.
 NEXT_PUBLIC_SOLANA_CLUSTER=devnet

--- a/src/app/[locale]/create/_lib/useEncryptedDraftCollaboration.ts
+++ b/src/app/[locale]/create/_lib/useEncryptedDraftCollaboration.ts
@@ -9,6 +9,7 @@ import {
 	type ShareableDraft,
 	shareableDraftFromState,
 } from "./secureDraftShare";
+import { fetchWithTimeout, REQUEST_TIMEOUT_MS } from "@/lib/fetchTimeout";
 
 const POLL_MS = 4_000;
 const PUBLISH_DEBOUNCE_MS = 1_500;
@@ -52,16 +53,20 @@ async function postSnapshot(input: {
 	readonly authorWallet: string | undefined;
 	readonly updatedAt: string;
 }): Promise<void> {
-	const response = await fetch(`/api/create-collab/${encodeURIComponent(input.roomId)}`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			eventId: input.eventId,
-			encryptedDraft: input.encryptedDraft,
-			authorWallet: input.authorWallet ?? null,
-			updatedAt: input.updatedAt,
-		}),
-	});
+	const response = await fetchWithTimeout(
+		`/api/create-collab/${encodeURIComponent(input.roomId)}`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				eventId: input.eventId,
+				encryptedDraft: input.encryptedDraft,
+				authorWallet: input.authorWallet ?? null,
+				updatedAt: input.updatedAt,
+			}),
+		},
+		REQUEST_TIMEOUT_MS.collaboration,
+	);
 	if (!response.ok) {
 		throw new Error("Unable to publish the live draft update.");
 	}
@@ -74,7 +79,11 @@ function isDocumentVisible(): boolean {
 async function fetchSnapshot(roomId: string, signal?: AbortSignal): Promise<RelaySnapshot | null> {
 	const init: RequestInit = { cache: "no-store" };
 	if (signal !== undefined) init.signal = signal;
-	const response = await fetch(`/api/create-collab/${encodeURIComponent(roomId)}`, init);
+	const response = await fetchWithTimeout(
+		`/api/create-collab/${encodeURIComponent(roomId)}`,
+		init,
+		REQUEST_TIMEOUT_MS.collaboration,
+	);
 	if (!response.ok) {
 		throw new Error(
 			"Unable To Load The Live Draft Room. Check The Session Link, Session Key, Wallet, Or Room Expiration.",

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1328,19 +1328,18 @@ export default function DashboardPage(): React.JSX.Element {
 	useEffect(() => {
 		if (!isConnected || address === undefined) return;
 		let active = true;
+		let timer: number | null = null;
 		void readDashboardVisitedPreference().then((visited) => {
 			if (!active || visited) return;
-			const timer = window.setTimeout(() => {
+			timer = window.setTimeout(() => {
 				if (!active) return;
 				setShowIntroActions(true);
 				setWalkthroughOpen(true);
 			}, 0);
-			return (): void => {
-				window.clearTimeout(timer);
-			};
 		});
 		return (): void => {
 			active = false;
+			if (timer !== null) window.clearTimeout(timer);
 		};
 	}, [address, isConnected]);
 

--- a/src/app/[locale]/status/_components/GitHubStatsSection.tsx
+++ b/src/app/[locale]/status/_components/GitHubStatsSection.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface GitHubAnalyticsSummary {
+	readonly available: true;
+	readonly repository: {
+		readonly fullName: string;
+		readonly url: string;
+		readonly defaultBranch: string;
+		readonly pushedAt: string | null;
+	};
+	readonly metrics: {
+		readonly commits: number | null;
+		readonly pullRequests: number | null;
+		readonly stars: number;
+		readonly forks: number;
+		readonly watchers: number;
+		readonly openIssues: number;
+		readonly repositorySizeKb: number;
+		readonly additions: number | null;
+		readonly deletions: number | null;
+		readonly changedLines: number | null;
+		readonly topLanguage: string | null;
+		readonly languageCount: number;
+	};
+	readonly checkedAt: string;
+}
+
+type GitHubAnalyticsResponse = GitHubAnalyticsSummary | { readonly available: false };
+
+function formatMetric(value: number | null, fallback: string): string {
+	return value === null ? fallback : new Intl.NumberFormat().format(value);
+}
+
+function formatStorage(kilobytes: number): string {
+	if (kilobytes >= 1024) {
+		return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(kilobytes / 1024)} MB`;
+	}
+	return `${new Intl.NumberFormat().format(kilobytes)} KB`;
+}
+
+function StatCell({
+	label,
+	value,
+	detail,
+}: {
+	readonly label: string;
+	readonly value: string;
+	readonly detail: string;
+}): React.JSX.Element {
+	return (
+		<div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-white/10 dark:bg-gray-950">
+			<p className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</p>
+			<p className="mt-2 text-2xl font-semibold text-gray-950 dark:text-white">{value}</p>
+			<p className="mt-1 text-sm text-gray-600 dark:text-gray-300">{detail}</p>
+		</div>
+	);
+}
+
+export function GitHubStatsSection(): React.JSX.Element | null {
+	const t = useTranslations("Status.github");
+	const [summary, setSummary] = useState<GitHubAnalyticsSummary | null>(null);
+
+	useEffect(() => {
+		const controller = new AbortController();
+		async function loadGitHubAnalytics(): Promise<void> {
+			try {
+				const response = await fetch("/api/analytics/github", {
+					headers: { Accept: "application/json" },
+					signal: controller.signal,
+				});
+				if (!response.ok || response.status === 204) return;
+				const payload = (await response.json()) as GitHubAnalyticsResponse;
+				if (payload.available) setSummary(payload);
+			} catch (error) {
+				if (!controller.signal.aborted) {
+					console.warn("GitHub analytics unavailable", error);
+				}
+			}
+		}
+		void loadGitHubAnalytics();
+		return (): void => {
+			controller.abort();
+		};
+	}, []);
+
+	if (summary === null) return null;
+
+	const pending = t("pending");
+	const topLanguage = summary.metrics.topLanguage ?? t("languageUnknown");
+	const updatedLabel =
+		summary.repository.pushedAt === null
+			? t("updatedUnknown")
+			: new Intl.DateTimeFormat(undefined, {
+					dateStyle: "medium",
+					timeStyle: "short",
+				}).format(new Date(summary.repository.pushedAt));
+
+	return (
+		<section className="mt-8 rounded-2xl border border-gray-200 bg-gray-50 p-6 dark:border-white/10 dark:bg-white/[0.03]">
+			<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start">
+				<div>
+					<p className="text-sm font-semibold text-indigo-600 dark:text-indigo-300">
+						{t("eyebrow")}
+					</p>
+					<h2 className="mt-2 text-2xl font-semibold text-gray-950 dark:text-white">
+						{t("title")}
+					</h2>
+					<p className="mt-2 max-w-3xl text-sm leading-6 text-gray-600 dark:text-gray-300">
+						{t("body", { repository: summary.repository.fullName })}
+					</p>
+				</div>
+				<a
+					href={summary.repository.url}
+					target="_blank"
+					rel="noreferrer"
+					className="tl-button-motion inline-flex min-h-11 items-center justify-center rounded-xl border border-gray-200 bg-white px-5 py-2.5 text-sm font-semibold text-gray-700 hover:border-gray-300 hover:text-gray-950 dark:border-white/10 dark:bg-gray-950 dark:text-gray-200 dark:hover:border-white/20 dark:hover:text-white"
+				>
+					{t("openRepository")}
+				</a>
+			</div>
+
+			<div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+				<StatCell
+					label={t("commits")}
+					value={formatMetric(summary.metrics.commits, pending)}
+					detail={t("defaultBranch", { branch: summary.repository.defaultBranch })}
+				/>
+				<StatCell
+					label={t("pullRequests")}
+					value={formatMetric(summary.metrics.pullRequests, pending)}
+					detail={t("issues", { count: summary.metrics.openIssues })}
+				/>
+				<StatCell
+					label={t("codeChanges")}
+					value={formatMetric(summary.metrics.changedLines, pending)}
+					detail={t("lineDelta", {
+						additions: formatMetric(summary.metrics.additions, pending),
+						deletions: formatMetric(summary.metrics.deletions, pending),
+					})}
+				/>
+				<StatCell
+					label={t("community")}
+					value={formatMetric(summary.metrics.stars, pending)}
+					detail={t("forksWatchers", {
+						forks: summary.metrics.forks,
+						watchers: summary.metrics.watchers,
+					})}
+				/>
+			</div>
+
+			<dl className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
+				<div className="flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-white px-4 py-3 dark:border-white/10 dark:bg-gray-950">
+					<dt className="text-gray-500 dark:text-gray-400">{t("topLanguage")}</dt>
+					<dd className="font-medium text-gray-900 dark:text-white">
+						{t("languageSummary", {
+							language: topLanguage,
+							count: summary.metrics.languageCount,
+						})}
+					</dd>
+				</div>
+				<div className="flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-white px-4 py-3 dark:border-white/10 dark:bg-gray-950">
+					<dt className="text-gray-500 dark:text-gray-400">{t("repoSize")}</dt>
+					<dd className="font-medium text-gray-900 dark:text-white">
+						{formatStorage(summary.metrics.repositorySizeKb)}
+					</dd>
+				</div>
+				<div className="flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-white px-4 py-3 dark:border-white/10 dark:bg-gray-950">
+					<dt className="text-gray-500 dark:text-gray-400">{t("lastPush")}</dt>
+					<dd className="text-right font-medium text-gray-900 dark:text-white">
+						{updatedLabel}
+					</dd>
+				</div>
+			</dl>
+		</section>
+	);
+}

--- a/src/app/[locale]/status/page.tsx
+++ b/src/app/[locale]/status/page.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@/i18n/navigation";
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { GitHubStatsSection } from "./_components/GitHubStatsSection";
 
 export async function generateMetadata({
 	params,
@@ -61,6 +62,8 @@ export default async function StatusPage({
 					</a>
 				))}
 			</section>
+
+			<GitHubStatsSection />
 
 			<div className="mt-8">
 				<Link

--- a/src/app/api/analytics/github/route.ts
+++ b/src/app/api/analytics/github/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { getGitHubAnalytics } from "@/services/githubAnalytics";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse> {
+	const analytics = await getGitHubAnalytics();
+	if (!analytics.available) return new NextResponse(null, { status: 204 });
+	return NextResponse.json(analytics);
+}

--- a/src/app/api/contract/[id]/route.ts
+++ b/src/app/api/contract/[id]/route.ts
@@ -36,7 +36,10 @@ export async function GET(
 	if (TRUSTLEDGER_ADDRESS === "0x0000000000000000000000000000000000000000")
 		return NextResponse.json({ error: "TrustLedger address not configured" }, { status: 500 });
 
-	const client = createPublicClient({ chain: sepolia, transport: http(rpcUrl) });
+	const client = createPublicClient({
+		chain: sepolia,
+		transport: http(rpcUrl, { retryCount: 1, timeout: 10_000 }),
+	});
 
 	let c: {
 		client: string;

--- a/src/app/api/contract/[id]/summary/route.ts
+++ b/src/app/api/contract/[id]/summary/route.ts
@@ -4,6 +4,7 @@ import { sepolia } from "viem/chains";
 import { STATUS_LABELS, TRUSTLEDGER_ABI } from "@/lib/abi";
 import { getUsdcAddress, TRUSTLEDGER_ADDRESS } from "@/lib/wagmi";
 import { summarizeContract } from "@/services/contractSummary";
+import type { Contract } from "@/types";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +17,27 @@ function tokenSymbol(token: string): "ETH" | "USDC" | "Unknown" {
 	if (token === "0x0000000000000000000000000000000000000000") return "ETH";
 	if (token.toLowerCase() === getUsdcAddress(sepolia.id)?.toLowerCase()) return "USDC";
 	return "Unknown";
+}
+
+function isAddress(value: unknown): value is `0x${string}` {
+	return typeof value === "string" && /^0x[a-fA-F0-9]{40}$/.test(value);
+}
+
+function isContract(value: unknown): value is Contract {
+	if (typeof value !== "object" || value === null) return false;
+	const record = value as Record<string, unknown>;
+	return (
+		isAddress(record["client"]) &&
+		isAddress(record["freelancer"]) &&
+		isAddress(record["token"]) &&
+		typeof record["status"] === "number" &&
+		typeof record["amount"] === "bigint" &&
+		typeof record["projectDeadline"] === "bigint" &&
+		typeof record["acceptanceDeadline"] === "bigint" &&
+		typeof record["warrantyDeadline"] === "bigint" &&
+		typeof record["holdBackBps"] === "number" &&
+		typeof record["proposedByClient"] === "boolean"
+	);
 }
 
 export async function GET(
@@ -32,13 +54,26 @@ export async function GET(
 	if (TRUSTLEDGER_ADDRESS === "0x0000000000000000000000000000000000000000")
 		return NextResponse.json({ error: "TrustLedger address not configured" }, { status: 500 });
 
-	const client = createPublicClient({ chain: sepolia, transport: http(rpcUrl) });
-	const contract = await client.readContract({
-		address: TRUSTLEDGER_ADDRESS,
-		abi: TRUSTLEDGER_ABI,
-		functionName: "getContract",
-		args: [BigInt(id)],
+	const client = createPublicClient({
+		chain: sepolia,
+		transport: http(rpcUrl, { retryCount: 1, timeout: 10_000 }),
 	});
+	let contract: Contract;
+	try {
+		const result = await client.readContract({
+			address: TRUSTLEDGER_ADDRESS,
+			abi: TRUSTLEDGER_ABI,
+			functionName: "getContract",
+			args: [BigInt(id)],
+		});
+		if (!isContract(result)) throw new Error("contract response had an unexpected shape");
+		contract = result;
+	} catch (error) {
+		return NextResponse.json(
+			{ error: error instanceof Error ? error.message : "failed to read contract" },
+			{ status: 502 },
+		);
+	}
 	const symbol = tokenSymbol(contract.token);
 	const contractHash = keccak256(
 		toBytes(

--- a/src/app/api/cron/deadline-reminders/route.ts
+++ b/src/app/api/cron/deadline-reminders/route.ts
@@ -64,7 +64,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
 	// `chain: sepolia` gives multicall the canonical Multicall3 address; the cron
 	// reads from SEPOLIA_RPC_URL, matching the testnet deployment.
-	const client = createPublicClient({ chain: sepolia, transport: http(rpcUrl) });
+	const client = createPublicClient({
+		chain: sepolia,
+		transport: http(rpcUrl, { retryCount: 1, timeout: 10_000 }),
+	});
 	const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 	const emailMap = loadEmailMap();
 

--- a/src/components/ConnectButton.tsx
+++ b/src/components/ConnectButton.tsx
@@ -19,6 +19,11 @@ function prepareWalletUi(): void {
 	void preloadWalletButton();
 }
 
+function WalletButtonLoading(): React.JSX.Element {
+	const t = useTranslations("Common");
+	return <ConnectButtonShell compact label={t("openingWallet")} busy />;
+}
+
 const WalletButton = dynamic(
 	async () => {
 		const mod = await preloadWalletButton();
@@ -26,7 +31,7 @@ const WalletButton = dynamic(
 	},
 	{
 		ssr: false,
-		loading: () => <ConnectButtonShell compact />,
+		loading: () => <WalletButtonLoading />,
 	},
 );
 
@@ -45,11 +50,13 @@ function ConnectButtonShell({
 	onClick,
 	onPrepare,
 	label,
+	busy = false,
 }: {
 	compact?: boolean;
 	onClick?: () => void;
 	onPrepare?: () => void;
 	label?: string;
+	busy?: boolean;
 }): React.JSX.Element {
 	const t = useTranslations("Common");
 	const className =
@@ -59,6 +66,7 @@ function ConnectButtonShell({
 	return (
 		<button
 			type="button"
+			aria-busy={busy}
 			onClick={onClick}
 			onFocus={onPrepare}
 			onPointerEnter={onPrepare}
@@ -88,6 +96,7 @@ function ConnectButtonShell({
 
 export function ConnectButton({ compact = false }: { compact?: boolean } = {}): React.JSX.Element {
 	const [loadWalletUi, setLoadWalletUi] = useState(false);
+	const [loadingWalletUi, setLoadingWalletUi] = useState(false);
 	const [openOnLoadKey, setOpenOnLoadKey] = useState(0);
 	const { address, isConnected, connector } = useAccount();
 	const t = useTranslations("Common");
@@ -101,6 +110,7 @@ export function ConnectButton({ compact = false }: { compact?: boolean } = {}): 
 	}, [isConnected, mounted, connector?.name]);
 
 	function loadAndOpen(): void {
+		setLoadingWalletUi(true);
 		setLoadWalletUi(true);
 		if (!isConnected) {
 			setOpenOnLoadKey((value) => value + 1);
@@ -108,6 +118,7 @@ export function ConnectButton({ compact = false }: { compact?: boolean } = {}): 
 	}
 
 	const shouldLoadWalletUi = loadWalletUi || (mounted && isConnected);
+	const shellLabel = loadingWalletUi ? t("openingWallet") : undefined;
 
 	if (!shouldLoadWalletUi) {
 		const remembered = mounted ? getLastWallet() : null;
@@ -122,7 +133,8 @@ export function ConnectButton({ compact = false }: { compact?: boolean } = {}): 
 				compact={compact}
 				onClick={loadAndOpen}
 				onPrepare={prepareWalletUi}
-				label={label}
+				label={shellLabel ?? label}
+				busy={loadingWalletUi}
 			/>
 		);
 	}

--- a/src/components/ConnectButtonInner.tsx
+++ b/src/components/ConnectButtonInner.tsx
@@ -2,7 +2,7 @@
 
 import { useAppKit, useAppKitTheme } from "@reown/appkit/react";
 import { useTheme } from "next-themes";
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useAccount } from "wagmi";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
@@ -118,6 +118,17 @@ export function ConnectButtonInner({
 	const [walletMenuOpen, setWalletMenuOpen] = useState(false);
 	const lastOpenedKeyRef = useRef(0);
 	const walletMenuRef = useRef<HTMLDivElement>(null);
+	const copyFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const clearCopyFeedbackTimer = useCallback((): void => {
+		if (copyFeedbackTimerRef.current !== null) {
+			clearTimeout(copyFeedbackTimerRef.current);
+			copyFeedbackTimerRef.current = null;
+		}
+	}, []);
+
+	useEffect(() => {
+		return clearCopyFeedbackTimer;
+	}, [clearCopyFeedbackTimer]);
 
 	// Persist the connector label (localStorage only - no React state) whenever a
 	// connection is active, so the reconnect hint survives logout / session expiry.
@@ -202,8 +213,10 @@ export function ConnectButtonInner({
 		const copyAddress = (): void => {
 			void navigator.clipboard.writeText(address).then(() => {
 				setCopied(true);
-				setTimeout(() => {
+				clearCopyFeedbackTimer();
+				copyFeedbackTimerRef.current = setTimeout(() => {
 					setCopied(false);
+					copyFeedbackTimerRef.current = null;
 				}, 1500);
 			});
 		};

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -33,6 +33,7 @@ declare namespace NodeJS {
 		NEXT_PUBLIC_SITE_URL?: string;
 		NEXT_PUBLIC_APP_URL?: string;
 		NEXT_PUBLIC_GITHUB_URL?: string;
+		GITHUB_TOKEN?: string;
 		NEXT_PUBLIC_PINATA_JWT?: string;
 		NEXT_PUBLIC_ENABLE_REACT_SCAN?: string;
 		ORACLE_PRICE_SOURCE_URL?: string;

--- a/src/lib/accountPreferences.ts
+++ b/src/lib/accountPreferences.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { fetchWithTimeout, REQUEST_TIMEOUT_MS } from "@/lib/fetchTimeout";
+
 const DASHBOARD_VISITED_KEY = "tl_visited";
 const PROFILE_STORAGE_HANDLE = ["trustledger", "profile", "handle"].join(":");
 
@@ -30,9 +32,13 @@ export async function readDashboardVisitedPreference(): Promise<boolean> {
 	if (token === null || token === "") return localVisited;
 
 	try {
-		const response = await fetch("/api/accounts/profile", {
-			headers: { authorization: `Bearer ${token}` },
-		});
+		const response = await fetchWithTimeout(
+			"/api/accounts/profile",
+			{
+				headers: { authorization: `Bearer ${token}` },
+			},
+			REQUEST_TIMEOUT_MS.accountPreference,
+		);
 		if (!response.ok) return localVisited;
 		const payload = (await response.json()) as {
 			profile?: { onboardingComplete?: unknown };
@@ -53,14 +59,18 @@ export async function markDashboardVisitedPreference(): Promise<void> {
 	}
 	if (token === null || token === "") return;
 	try {
-		await fetch("/api/accounts/profile", {
-			method: "PATCH",
-			headers: {
-				"authorization": `Bearer ${token}`,
-				"content-type": "application/json",
+		await fetchWithTimeout(
+			"/api/accounts/profile",
+			{
+				method: "PATCH",
+				headers: {
+					"authorization": `Bearer ${token}`,
+					"content-type": "application/json",
+				},
+				body: JSON.stringify({ onboardingComplete: true }),
 			},
-			body: JSON.stringify({ onboardingComplete: true }),
-		});
+			REQUEST_TIMEOUT_MS.accountPreference,
+		);
 	} catch {
 		// Local storage is already updated, so the account write is best-effort.
 	}

--- a/src/lib/fetchTimeout.ts
+++ b/src/lib/fetchTimeout.ts
@@ -1,0 +1,60 @@
+export const REQUEST_TIMEOUT_MS = {
+	accountPreference: 4_000,
+	aiSummary: 12_000,
+	collaboration: 5_000,
+	emailProvider: 10_000,
+	githubAnalytics: 8_000,
+	ipfsUpload: 45_000,
+	oracle: 6_000,
+	rpcRead: 10_000,
+} as const;
+
+function timeoutSignal(timeoutMs: number, reason = "Request timed out."): AbortSignal {
+	const controller = new AbortController();
+	const timer = setTimeout(() => {
+		controller.abort(new DOMException(reason, "TimeoutError"));
+	}, timeoutMs);
+	controller.signal.addEventListener(
+		"abort",
+		() => {
+			clearTimeout(timer);
+		},
+		{ once: true },
+	);
+	return controller.signal;
+}
+
+function mergeAbortSignals(...signals: (AbortSignal | undefined)[]): AbortSignal | undefined {
+	const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+	if (activeSignals.length === 0) return undefined;
+	if (activeSignals.length === 1) return activeSignals[0];
+
+	const controller = new AbortController();
+	for (const signal of activeSignals) {
+		if (signal.aborted) {
+			controller.abort(signal.reason);
+			return controller.signal;
+		}
+		signal.addEventListener(
+			"abort",
+			() => {
+				controller.abort(signal.reason);
+			},
+			{ once: true },
+		);
+	}
+	return controller.signal;
+}
+
+export async function fetchWithTimeout(
+	input: RequestInfo | URL,
+	init: RequestInit = {},
+	timeoutMs: number = REQUEST_TIMEOUT_MS.rpcRead,
+): Promise<Response> {
+	const signal = mergeAbortSignals(init.signal ?? undefined, timeoutSignal(timeoutMs));
+	const nextInit: RequestInit = { ...init };
+	if (signal !== undefined) {
+		nextInit.signal = signal;
+	}
+	return await fetch(input, nextInit);
+}

--- a/src/lib/ipfs.ts
+++ b/src/lib/ipfs.ts
@@ -1,6 +1,8 @@
 // Upload a file to IPFS via Pinata's pinning API.
 // jwt: Pinata API JWT (set NEXT_PUBLIC_PINATA_JWT in .env.local or pass at runtime).
 // Returns an "ipfs://<CID>" URI suitable for storing on-chain.
+import { fetchWithTimeout, REQUEST_TIMEOUT_MS } from "@/lib/fetchTimeout";
+
 export async function uploadToPinata(
 	file: File | Blob,
 	name: string,
@@ -11,11 +13,15 @@ export async function uploadToPinata(
 	body.append("pinataMetadata", JSON.stringify({ name }));
 	body.append("pinataOptions", JSON.stringify({ cidVersion: 1 }));
 
-	const res = await fetch("https://api.pinata.cloud/pinning/pinFileToIPFS", {
-		method: "POST",
-		headers: { Authorization: `Bearer ${jwt}` },
-		body,
-	});
+	const res = await fetchWithTimeout(
+		"https://api.pinata.cloud/pinning/pinFileToIPFS",
+		{
+			method: "POST",
+			headers: { Authorization: `Bearer ${jwt}` },
+			body,
+		},
+		REQUEST_TIMEOUT_MS.ipfsUpload,
+	);
 
 	if (!res.ok) {
 		const text = await res.text();

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -640,6 +640,7 @@
 	},
 	"Common": {
 		"connectWallet": "ربط المحفظة",
+		"openingWallet": "جارٍ فتح المحفظة...",
 		"reconnectWith": "إعادة الاتصال بـ {wallet}",
 		"connectedAs": "متصل كـ {address}. انقر لفتح خيارات المحفظة.",
 		"addressCopied": "تم نسخ العنوان",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Full Health Report",
 			"publicStatusApi": "Public Status API",
 			"scientificAnalyticsApi": "Scientific Analytics API"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -696,6 +696,7 @@
 	},
 	"Common": {
 		"connectWallet": "Connect Wallet",
+		"openingWallet": "Opening Wallet...",
 		"reconnectWith": "Reconnect with {wallet}",
 		"connectedAs": "Connected as {address}. Click to open wallet options.",
 		"addressCopied": "Address copied",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Full Health Report",
 			"publicStatusApi": "Public Status API",
 			"scientificAnalyticsApi": "Scientific Analytics API"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -640,6 +640,7 @@
 	},
 	"Common": {
 		"connectWallet": "Conectar Billetera",
+		"openingWallet": "Abriendo Billetera...",
 		"reconnectWith": "Reconectar con {wallet}",
 		"connectedAs": "Conectado como {address}. Haz clic para abrir opciones de billetera.",
 		"addressCopied": "Dirección copiada",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Informe Completo de Salud",
 			"publicStatusApi": "API Pública de Estado",
 			"scientificAnalyticsApi": "API de Analíticas Científicas"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/messages/fr.json
+++ b/src/messages/fr.json
@@ -640,6 +640,7 @@
 	},
 	"Common": {
 		"connectWallet": "Connecter le Portefeuille",
+		"openingWallet": "Ouverture Du Portefeuille...",
 		"reconnectWith": "Reconnecter avec {wallet}",
 		"connectedAs": "Connecté en tant que {address}. Cliquez pour ouvrir les options du portefeuille.",
 		"addressCopied": "Adresse copiée",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Rapport de Santé Complet",
 			"publicStatusApi": "API Publique d’État",
 			"scientificAnalyticsApi": "API d’Analyses Scientifiques"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/messages/hi.json
+++ b/src/messages/hi.json
@@ -640,6 +640,7 @@
 	},
 	"Common": {
 		"connectWallet": "वॉलेट कनेक्ट करें",
+		"openingWallet": "वॉलेट खुल रहा है...",
 		"reconnectWith": "{wallet} से फिर से कनेक्ट करें",
 		"connectedAs": "{address} के रूप में कनेक्ट हैं। वॉलेट विकल्प खोलने के लिए क्लिक करें।",
 		"addressCopied": "पता कॉपी हुआ",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Full Health Report",
 			"publicStatusApi": "Public Status API",
 			"scientificAnalyticsApi": "Scientific Analytics API"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/messages/pt.json
+++ b/src/messages/pt.json
@@ -640,6 +640,7 @@
 	},
 	"Common": {
 		"connectWallet": "Conectar Carteira",
+		"openingWallet": "Abrindo Carteira...",
 		"reconnectWith": "Reconectar com {wallet}",
 		"connectedAs": "Conectado como {address}. Clique para abrir opções da carteira.",
 		"addressCopied": "Endereço copiado",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Informe Completo de Salud",
 			"publicStatusApi": "API Pública de Estado",
 			"scientificAnalyticsApi": "API de Analíticas Científicas"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -640,6 +640,7 @@
 	},
 	"Common": {
 		"connectWallet": "Kết Nối Ví",
+		"openingWallet": "Đang Mở Ví...",
 		"reconnectWith": "Kết nối lại với {wallet}",
 		"connectedAs": "Đã kết nối với {address}. Nhấp để mở tùy chọn ví.",
 		"addressCopied": "Đã sao chép địa chỉ",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Full Health Report",
 			"publicStatusApi": "Public Status API",
 			"scientificAnalyticsApi": "Scientific Analytics API"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -640,6 +640,7 @@
 	},
 	"Common": {
 		"connectWallet": "连接钱包",
+		"openingWallet": "正在打开钱包...",
 		"reconnectWith": "重新连接 {wallet}",
 		"connectedAs": "已连接为 {address}。点击打开钱包选项。",
 		"addressCopied": "地址已复制",
@@ -955,6 +956,27 @@
 			"fullHealthReport": "Full Health Report",
 			"publicStatusApi": "Public Status API",
 			"scientificAnalyticsApi": "Scientific Analytics API"
+		},
+		"github": {
+			"eyebrow": "Public Repository Analytics",
+			"title": "GitHub Project Activity",
+			"body": "Public repository activity for {repository}. This section appears only when the configured GitHub repository is public.",
+			"openRepository": "Open Repository",
+			"commits": "Commits",
+			"defaultBranch": "Default branch: {branch}",
+			"pullRequests": "Pull Requests",
+			"issues": "{count} open issues",
+			"codeChanges": "Code Changes",
+			"lineDelta": "+{additions} / -{deletions} lines",
+			"community": "Stars",
+			"forksWatchers": "{forks} forks, {watchers} watchers",
+			"topLanguage": "Top Language",
+			"languageSummary": "{language} across {count} languages",
+			"repoSize": "Repository Size",
+			"lastPush": "Last Push",
+			"updatedUnknown": "Unknown",
+			"languageUnknown": "Unknown",
+			"pending": "Indexing"
 		}
 	},
 	"NotFound": {

--- a/src/services/contractSummary.ts
+++ b/src/services/contractSummary.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { createHash } from "node:crypto";
+import { fetchWithTimeout, REQUEST_TIMEOUT_MS } from "@/lib/fetchTimeout";
 
 export type ContractSummaryProvider = "disabled" | "groq" | "gemini";
 
@@ -104,26 +105,30 @@ async function callGroq(input: ContractSummaryInput): Promise<string> {
 	const apiKey = process.env["GROQ_API_KEY"];
 	if (apiKey === undefined || apiKey === "") throw new Error("GROQ_API_KEY not set");
 	const model = process.env["GROQ_MODEL"] ?? "llama-3.3-70b-versatile";
-	const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
-		method: "POST",
-		headers: {
-			"authorization": `Bearer ${apiKey}`,
-			"content-type": "application/json",
+	const response = await fetchWithTimeout(
+		"https://api.groq.com/openai/v1/chat/completions",
+		{
+			method: "POST",
+			headers: {
+				"authorization": `Bearer ${apiKey}`,
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				model,
+				temperature: 0.2,
+				max_tokens: 120,
+				messages: [
+					{
+						role: "system",
+						content:
+							"You write precise escrow-contract summaries for a privacy-focused SaaS product.",
+					},
+					{ role: "user", content: prompt(input) },
+				],
+			}),
 		},
-		body: JSON.stringify({
-			model,
-			temperature: 0.2,
-			max_tokens: 120,
-			messages: [
-				{
-					role: "system",
-					content:
-						"You write precise escrow-contract summaries for a privacy-focused SaaS product.",
-				},
-				{ role: "user", content: prompt(input) },
-			],
-		}),
-	});
+		REQUEST_TIMEOUT_MS.aiSummary,
+	);
 	if (!response.ok) throw new Error(`Groq summary failed: ${response.status.toString()}`);
 	const body = (await response.json()) as {
 		choices?: readonly { message?: { content?: string } }[];
@@ -137,7 +142,7 @@ async function callGemini(input: ContractSummaryInput): Promise<string> {
 	const apiKey = process.env["GEMINI_API_KEY"] ?? process.env["GOOGLE_GENERATIVE_AI_API_KEY"];
 	if (apiKey === undefined || apiKey === "") throw new Error("GEMINI_API_KEY not set");
 	const model = process.env["GEMINI_MODEL"] ?? "gemini-2.5-flash";
-	const response = await fetch(
+	const response = await fetchWithTimeout(
 		`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
 		{
 			method: "POST",
@@ -147,6 +152,7 @@ async function callGemini(input: ContractSummaryInput): Promise<string> {
 				contents: [{ parts: [{ text: prompt(input) }] }],
 			}),
 		},
+		REQUEST_TIMEOUT_MS.aiSummary,
 	);
 	if (!response.ok) throw new Error(`Gemini summary failed: ${response.status.toString()}`);
 	const body = (await response.json()) as {

--- a/src/services/email.ts
+++ b/src/services/email.ts
@@ -3,6 +3,7 @@
 // a shared HTML shell and one server-only integration boundary.
 
 import { Resend } from "resend";
+import { fetchWithTimeout, REQUEST_TIMEOUT_MS } from "@/lib/fetchTimeout";
 
 /** Brand accent shared with the rest of the UI (indigo-500). */
 const ACCENT = "#6366f1";
@@ -144,11 +145,15 @@ async function postJson(
 	headers: Readonly<Record<string, string>>,
 	body: object,
 ): Promise<string | null> {
-	const response = await fetch(url, {
-		method: "POST",
-		headers: { "content-type": "application/json", ...headers },
-		body: JSON.stringify(body),
-	});
+	const response = await fetchWithTimeout(
+		url,
+		{
+			method: "POST",
+			headers: { "content-type": "application/json", ...headers },
+			body: JSON.stringify(body),
+		},
+		REQUEST_TIMEOUT_MS.emailProvider,
+	);
 	if (response.ok) return null;
 	const text = await response.text();
 	return text === "" ? response.statusText : text;

--- a/src/services/githubAnalytics.ts
+++ b/src/services/githubAnalytics.ts
@@ -1,0 +1,273 @@
+import { fetchWithTimeout, REQUEST_TIMEOUT_MS } from "@/lib/fetchTimeout";
+
+interface GitHubRepositoryResponse {
+	readonly full_name?: unknown;
+	readonly html_url?: unknown;
+	readonly private?: unknown;
+	readonly stargazers_count?: unknown;
+	readonly forks_count?: unknown;
+	readonly watchers_count?: unknown;
+	readonly open_issues_count?: unknown;
+	readonly default_branch?: unknown;
+	readonly pushed_at?: unknown;
+	readonly size?: unknown;
+}
+
+interface GitHubContributorStatsResponse {
+	readonly weeks?: readonly {
+		readonly a?: unknown;
+		readonly d?: unknown;
+		readonly c?: unknown;
+	}[];
+}
+
+interface GitHubAnalyticsSummary {
+	readonly available: true;
+	readonly repository: {
+		readonly owner: string;
+		readonly name: string;
+		readonly fullName: string;
+		readonly url: string;
+		readonly defaultBranch: string;
+		readonly pushedAt: string | null;
+	};
+	readonly metrics: {
+		readonly commits: number | null;
+		readonly pullRequests: number | null;
+		readonly stars: number;
+		readonly forks: number;
+		readonly watchers: number;
+		readonly openIssues: number;
+		readonly repositorySizeKb: number;
+		readonly additions: number | null;
+		readonly deletions: number | null;
+		readonly changedLines: number | null;
+		readonly topLanguage: string | null;
+		readonly languageCount: number;
+	};
+	readonly checkedAt: string;
+}
+
+interface GitHubAnalyticsUnavailable {
+	readonly available: false;
+	readonly reason: "missing_repo" | "invalid_repo" | "private_repo" | "fetch_failed";
+	readonly checkedAt: string;
+}
+
+export type GitHubAnalyticsResult = GitHubAnalyticsSummary | GitHubAnalyticsUnavailable;
+
+const GITHUB_API_BASE = "https://api.github.com";
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+let cachedResult: { readonly value: GitHubAnalyticsResult; readonly expiresAt: number } | null =
+	null;
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+function unavailable(reason: GitHubAnalyticsUnavailable["reason"]): GitHubAnalyticsUnavailable {
+	return { available: false, reason, checkedAt: nowIso() };
+}
+
+function parseGitHubRepoUrl(value: string | undefined): { owner: string; repo: string } | null {
+	if (value === undefined || value.trim() === "") return null;
+	const trimmed = value.trim();
+	const shorthandMatch = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/u.exec(trimmed);
+	if (shorthandMatch !== null) {
+		return {
+			owner: shorthandMatch[1] ?? "",
+			repo: (shorthandMatch[2] ?? "").replace(/\.git$/u, ""),
+		};
+	}
+
+	try {
+		const url = new URL(trimmed);
+		if (url.hostname !== "github.com" && url.hostname !== "www.github.com") return null;
+		const [owner, repo] = url.pathname
+			.replace(/^\/+?/u, "")
+			.split("/")
+			.map((segment) => segment.trim());
+		if (owner === undefined || repo === undefined || owner === "" || repo === "") return null;
+		return { owner, repo: repo.replace(/\.git$/u, "") };
+	} catch {
+		return null;
+	}
+}
+
+function configuredRepo(): { owner: string; repo: string } | null {
+	const owner = process.env["VERCEL_GIT_REPO_OWNER"];
+	const slug = process.env["VERCEL_GIT_REPO_SLUG"];
+	if (owner !== undefined && owner !== "" && slug !== undefined && slug !== "") {
+		return { owner, repo: slug };
+	}
+	return parseGitHubRepoUrl(process.env.NEXT_PUBLIC_GITHUB_URL);
+}
+
+function requestHeaders(): HeadersInit {
+	const headers: Record<string, string> = {
+		"Accept": "application/vnd.github+json",
+		"User-Agent": "TrustLedger-Public-Analytics",
+		"X-GitHub-Api-Version": "2022-11-28",
+	};
+	const token = process.env.GITHUB_TOKEN;
+	if (token !== undefined && token !== "") {
+		headers["Authorization"] = `Bearer ${token}`;
+	}
+	return headers;
+}
+
+async function fetchGitHubJson(path: string): Promise<{ data: unknown; headers: Headers }> {
+	const response = await fetchWithTimeout(
+		`${GITHUB_API_BASE}${path}`,
+		{ headers: requestHeaders() },
+		REQUEST_TIMEOUT_MS.githubAnalytics,
+	);
+	if (!response.ok) {
+		throw new Error(`GitHub request failed with ${response.status.toString()}`);
+	}
+	return { data: await response.json(), headers: response.headers };
+}
+
+function getLastPageCount(headers: Headers, fallbackCount: number): number {
+	const link = headers.get("link");
+	if (link === null || link === "") return fallbackCount;
+	const match = /[?&]page=(\d+)>;\s*rel="last"/u.exec(link);
+	return match === null ? fallbackCount : Number(match[1]);
+}
+
+function numberValue(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function stringValue(value: unknown, fallback: string): string {
+	return typeof value === "string" && value !== "" ? value : fallback;
+}
+
+async function fetchPagedCount(path: string): Promise<number | null> {
+	try {
+		const { data, headers } = await fetchGitHubJson(
+			`${path}${path.includes("?") ? "&" : "?"}per_page=1`,
+		);
+		return getLastPageCount(headers, Array.isArray(data) ? data.length : 0);
+	} catch {
+		return null;
+	}
+}
+
+async function fetchLanguageSummary(
+	owner: string,
+	repo: string,
+): Promise<{
+	readonly topLanguage: string | null;
+	readonly languageCount: number;
+}> {
+	try {
+		const { data } = await fetchGitHubJson(`/repos/${owner}/${repo}/languages`);
+		const languages = data as Record<string, number>;
+		const entries = Object.entries(languages).sort(([, left], [, right]) => right - left);
+		return {
+			topLanguage: entries[0]?.[0] ?? null,
+			languageCount: entries.length,
+		};
+	} catch {
+		return { topLanguage: null, languageCount: 0 };
+	}
+}
+
+async function fetchCodeChangeSummary(
+	owner: string,
+	repo: string,
+): Promise<{
+	readonly additions: number | null;
+	readonly deletions: number | null;
+	readonly changedLines: number | null;
+}> {
+	try {
+		const response = await fetchWithTimeout(
+			`${GITHUB_API_BASE}/repos/${owner}/${repo}/stats/contributors`,
+			{ headers: requestHeaders() },
+			REQUEST_TIMEOUT_MS.githubAnalytics,
+		);
+		if (response.status === 202) {
+			return { additions: null, deletions: null, changedLines: null };
+		}
+		if (!response.ok) throw new Error(`GitHub stats failed with ${response.status.toString()}`);
+		const contributors = (await response.json()) as GitHubContributorStatsResponse[];
+		const additions = contributors.reduce(
+			(total, contributor) =>
+				total +
+				(contributor.weeks ?? []).reduce((sum, week) => sum + numberValue(week.a), 0),
+			0,
+		);
+		const deletions = contributors.reduce(
+			(total, contributor) =>
+				total +
+				(contributor.weeks ?? []).reduce((sum, week) => sum + numberValue(week.d), 0),
+			0,
+		);
+		return { additions, deletions, changedLines: additions + deletions };
+	} catch {
+		return { additions: null, deletions: null, changedLines: null };
+	}
+}
+
+async function buildGitHubAnalytics(): Promise<GitHubAnalyticsResult> {
+	const repoConfig = configuredRepo();
+	if (repoConfig === null) return unavailable("missing_repo");
+	const { owner, repo } = repoConfig;
+	if (owner === "" || repo === "") return unavailable("invalid_repo");
+
+	try {
+		const { data } = await fetchGitHubJson(`/repos/${owner}/${repo}`);
+		const repository = data as GitHubRepositoryResponse;
+		if (repository.private !== false) return unavailable("private_repo");
+
+		const [commits, pullRequests, languages, codeChanges] = await Promise.all([
+			fetchPagedCount(`/repos/${owner}/${repo}/commits`),
+			fetchPagedCount(`/repos/${owner}/${repo}/pulls?state=all`),
+			fetchLanguageSummary(owner, repo),
+			fetchCodeChangeSummary(owner, repo),
+		]);
+
+		return {
+			available: true,
+			repository: {
+				owner,
+				name: repo,
+				fullName: stringValue(repository.full_name, `${owner}/${repo}`),
+				url: stringValue(repository.html_url, `https://github.com/${owner}/${repo}`),
+				defaultBranch: stringValue(repository.default_branch, "main"),
+				pushedAt:
+					typeof repository.pushed_at === "string" && repository.pushed_at !== ""
+						? repository.pushed_at
+						: null,
+			},
+			metrics: {
+				commits,
+				pullRequests,
+				stars: numberValue(repository.stargazers_count),
+				forks: numberValue(repository.forks_count),
+				watchers: numberValue(repository.watchers_count),
+				openIssues: numberValue(repository.open_issues_count),
+				repositorySizeKb: numberValue(repository.size),
+				additions: codeChanges.additions,
+				deletions: codeChanges.deletions,
+				changedLines: codeChanges.changedLines,
+				topLanguage: languages.topLanguage,
+				languageCount: languages.languageCount,
+			},
+			checkedAt: nowIso(),
+		};
+	} catch {
+		return unavailable("fetch_failed");
+	}
+}
+
+export async function getGitHubAnalytics(): Promise<GitHubAnalyticsResult> {
+	const now = Date.now();
+	if (cachedResult !== null && cachedResult.expiresAt > now) return cachedResult.value;
+	const value = await buildGitHubAnalytics();
+	cachedResult = { value, expiresAt: now + CACHE_TTL_MS };
+	return value;
+}

--- a/src/services/oracle.ts
+++ b/src/services/oracle.ts
@@ -1,3 +1,5 @@
+import { fetchWithTimeout, REQUEST_TIMEOUT_MS } from "@/lib/fetchTimeout";
+
 export interface OracleRate {
 	readonly base: OracleAsset;
 	readonly quote: OracleQuote;
@@ -130,10 +132,14 @@ export async function fetchOracleRate(base: OracleAsset, quote: OracleQuote): Pr
 
 	const url = buildOracleUrl(base, quote);
 	try {
-		const response = await fetch(url, {
-			headers: { accept: "application/json" },
-			cache: "no-store",
-		});
+		const response = await fetchWithTimeout(
+			url,
+			{
+				headers: { accept: "application/json" },
+				cache: "no-store",
+			},
+			REQUEST_TIMEOUT_MS.oracle,
+		);
 		if (!response.ok) {
 			throw new Error(`oracle source returned HTTP ${response.status.toString()}`);
 		}

--- a/src/tests/unit/github-analytics.test.ts
+++ b/src/tests/unit/github-analytics.test.ts
@@ -1,0 +1,132 @@
+const originalEnv = process.env;
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(
+	body: unknown,
+	init: { readonly status?: number; readonly headers?: Record<string, string> } = {},
+): Response {
+	const status = init.status ?? 200;
+	const headers = new Map<string, string>(
+		Object.entries({ "content-type": "application/json", ...(init.headers ?? {}) }),
+	);
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		headers: {
+			get(name: string): string | null {
+				return headers.get(name.toLowerCase()) ?? null;
+			},
+		},
+		async json(): Promise<unknown> {
+			await Promise.resolve();
+			return body;
+		},
+	} as Response;
+}
+
+describe("github analytics", () => {
+	afterEach(() => {
+		process.env = originalEnv;
+		globalThis.fetch = originalFetch;
+		jest.restoreAllMocks();
+		jest.resetModules();
+	});
+
+	it("rejects missing and non-GitHub repository references", async () => {
+		globalThis.fetch = jest.fn();
+		const { getGitHubAnalytics } = await import("@/services/githubAnalytics");
+
+		process.env = { ...originalEnv, NEXT_PUBLIC_GITHUB_URL: "" };
+		await expect(getGitHubAnalytics()).resolves.toMatchObject({
+			available: false,
+			reason: "missing_repo",
+		});
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+
+		jest.resetModules();
+		const invalidModule = await import("@/services/githubAnalytics");
+		process.env = {
+			...originalEnv,
+			NEXT_PUBLIC_GITHUB_URL: "https://gitlab.com/example/project",
+		};
+		await expect(invalidModule.getGitHubAnalytics()).resolves.toMatchObject({
+			available: false,
+			reason: "missing_repo",
+		});
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it("suppresses private repositories", async () => {
+		process.env = { ...originalEnv, NEXT_PUBLIC_GITHUB_URL: "https://github.com/acme/private" };
+		globalThis.fetch = jest
+			.fn()
+			.mockResolvedValue(jsonResponse({ private: true, full_name: "acme/private" }));
+
+		const { getGitHubAnalytics } = await import("@/services/githubAnalytics");
+		await expect(getGitHubAnalytics()).resolves.toMatchObject({
+			available: false,
+			reason: "private_repo",
+		});
+	});
+
+	it("returns public repository metrics", async () => {
+		process.env = { ...originalEnv, NEXT_PUBLIC_GITHUB_URL: "acme/public.git" };
+		globalThis.fetch = jest
+			.fn()
+			.mockResolvedValueOnce(
+				jsonResponse({
+					private: false,
+					full_name: "acme/public",
+					html_url: "https://github.com/acme/public",
+					stargazers_count: 12,
+					forks_count: 3,
+					watchers_count: 4,
+					open_issues_count: 2,
+					default_branch: "main",
+					pushed_at: "2026-06-10T12:00:00Z",
+					size: 2048,
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse([], {
+					headers: {
+						link: '<https://api.github.com/repositories/1/commits?per_page=1&page=44>; rel="last"',
+					},
+				}),
+			)
+			.mockResolvedValueOnce(
+				jsonResponse([], {
+					headers: {
+						link: '<https://api.github.com/repositories/1/pulls?state=all&per_page=1&page=7>; rel="last"',
+					},
+				}),
+			)
+			.mockResolvedValueOnce(jsonResponse({ TypeScript: 100, Solidity: 25 }))
+			.mockResolvedValueOnce(
+				jsonResponse([
+					{ weeks: [{ a: 10, d: 4, c: 2 }] },
+					{ weeks: [{ a: 5, d: 1, c: 1 }] },
+				]),
+			);
+
+		const { getGitHubAnalytics } = await import("@/services/githubAnalytics");
+		await expect(getGitHubAnalytics()).resolves.toMatchObject({
+			available: true,
+			repository: { fullName: "acme/public", defaultBranch: "main" },
+			metrics: {
+				commits: 44,
+				pullRequests: 7,
+				stars: 12,
+				forks: 3,
+				watchers: 4,
+				openIssues: 2,
+				repositorySizeKb: 2048,
+				additions: 15,
+				deletions: 5,
+				changedLines: 20,
+				topLanguage: "TypeScript",
+				languageCount: 2,
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- add public GitHub repository analytics for the status page
- add shared fetch timeout handling across network integrations
- document new GitHub/env configuration and update localized status copy

## Validation
- pre-commit hook passed
- pre-push hook passed, including quality, frontend build, E2E, Rust, Solana, and contract checks