### PR TITLE
docs: embed canonical quality standards into AI guidance files

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -62,6 +62,10 @@ Read root `AGENTS.md` first. This file only adds Codex-specific behavior.
   justification.
 - SWC changes: use `src/.agents/skills/swc-config/SKILL.md`, then run
   `npm run swc:populate` and the relevant build.
+- Quality standards: enforce `docs/QUALITY-STANDARDS.md`. React Doctor must stay
+  at 100/100; block merges and deployments when React Doctor, type-check, lint,
+  tests, build, accessibility, performance, or security checks fail. Validate
+  compliance before completing tasks.
 - React diagnostics: use `src/skills/react-doctor/SKILL.md` and keep the score
   from regressing.
 - Legal and compliance-sensitive changes: use

--- a/.cursor/instructions/precedence.md
+++ b/.cursor/instructions/precedence.md
@@ -11,3 +11,7 @@
 
 Cursor should route frontend, backend, contract, security, docs, and testing
 context based on the modified path globs in `.cursor/rules/`.
+
+All edits must comply with `docs/QUALITY-STANDARDS.md`: React Doctor stays at
+100/100, and merges and deployments are blocked when React Doctor, type-check,
+lint, tests, build, accessibility, performance, or security checks fail.

--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -11,4 +11,7 @@ Keep docs accurate, concise, and command-copyable. Use
 `src/.agents/skills/update-context/SKILL.md` after repository changes. Update
 README, environment, testing, CI, security, website, agent guidance, and roadmap
 docs whenever behavior, architecture, tools, security posture, or workflows
-change. Do not mark roadmap items complete without objective evidence.
+change. Do not mark roadmap items complete without objective evidence. Follow the
+documentation standards in `docs/QUALITY-STANDARDS.md`: TSDoc on new code
+elements, full API-route and smart-contract documentation, and docs kept in sync
+within the same PR.

--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -12,4 +12,7 @@ Use React, Next.js App Router, strict TypeScript, accessible controls, stable
 responsive layouts, localized copy, and existing Tailwind conventions. Keep
 wallet logic isolated to wagmi/Reown helpers and avoid exposing non-`NEXT_PUBLIC_*`
 values to the browser. Run `cd src && npx tsc --noEmit`, `npm run lint:frontend`,
-and relevant Jest/Playwright tests after frontend changes.
+and relevant Jest/Playwright tests after frontend changes. Enforce
+`docs/QUALITY-STANDARDS.md`: keep React Doctor at 100/100 (`npm run doctor`),
+hold the line on accessibility, re-render/performance, and bundle health, and
+do not merge below 100/100.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,11 @@
 
 Follow root `AGENTS.md` and `.copilot/instructions.md`.
 
+Enforce `docs/QUALITY-STANDARDS.md`: React Doctor must stay at 100/100, and no
+merge or deployment may proceed when React Doctor, type-check, lint, tests,
+build, accessibility, performance, or security checks fail. Validate compliance
+before completing changes.
+
 Use the path-specific `.cursor/rules/*.mdc` files for frontend, backend,
 contract, security, testing, and documentation routing.
 

--- a/.serena/memories/quality_standards.md
+++ b/.serena/memories/quality_standards.md
@@ -1,0 +1,28 @@
+# Quality Standards
+
+Canonical spec: `docs/QUALITY-STANDARDS.md`. Enforce before completing any task
+or approving any change.
+
+## Hard Gates (block merge/deploy/release on failure)
+
+- React Doctor = 100/100 (`npm run doctor` from `src/`). No exceptions; resolve
+  regressions and warnings proactively.
+- Type-check (`npx tsc --noEmit`), lint/format, tests (`forge`/Jest/Playwright),
+  build (`forge build`, `next build`), accessibility, performance, security
+  (Semgrep, `security.yml`).
+
+## Invariants
+
+- Remove dead code/imports/assets/duplication your change exposes; respect scope
+  (`AGENTS.md` Code Hygiene — surface unrelated dead code, do not delete).
+- TSDoc on new functions/classes/types/hooks/services/controllers/public APIs.
+- Document every API route and smart-contract surface; keep docs in sync in the
+  same PR.
+- Maintain `controllers/` business-logic separation and `CREDITS.md`.
+- Bound external fetches/RPC with explicit timeouts (`src/lib/fetchTimeout.ts`).
+
+## Verify After Changes
+
+React Doctor 100/100, build, type-check, lint, tests, a11y, mobile
+responsiveness all pass; no memory spikes, freezes, regressions, warnings, or
+doc gaps. Report failures and skips faithfully with evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,29 @@ commands with `rtk` when available.
   instead of duplicating long instructions, unless the target agent does not
   support reference-style guidance.
 
+## Quality Standards (Mandatory)
+
+`docs/QUALITY-STANDARDS.md` is the canonical documentation, quality,
+performance, accessibility, and deployment specification. All agents must
+enforce it and validate compliance before completing tasks or approving changes.
+Non-negotiables:
+
+- React Doctor must stay at 100/100. No PR, merge, release, deployment, or
+  production promotion may proceed below 100/100. Treat failures, warnings,
+  regressions, and recommendations as high priority.
+- Block deployments and merges when React Doctor, type-check, lint, tests,
+  build, accessibility, performance, or security checks fail.
+- Remove unused code, dead files, stale imports, obsolete assets, duplicate
+  logic, and unreachable code introduced or exposed by your change.
+- Add TSDoc to new functions, classes, types, hooks, services, controllers, and
+  public APIs; document API routes, smart-contract surfaces, and keep docs in
+  sync within the same PR.
+- Maintain the `controllers/` directory for business-logic separation and the
+  `CREDITS.md` acknowledgements file.
+
+See `docs/QUALITY-STANDARDS.md` for the full eleven-point specification and
+verification checklist.
+
 ## Code Hygiene (Mandatory)
 
 These rules are mandatory when refactoring, migrating, or moving/renaming files:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,24 @@ npm run doctor            # React Doctor (score + verbose findings)
 
 ---
 
+## 7.1 Quality Standards (Mandatory)
+
+`docs/QUALITY-STANDARDS.md` is the canonical documentation, quality,
+performance, accessibility, and deployment specification. Enforce it and
+validate compliance before completing any task or approving any change.
+
+- React Doctor must stay at 100/100. No PR, merge, release, deployment, or
+  production promotion may proceed below 100/100. Proactively identify and
+  resolve anything blocking the score; treat warnings and regressions as
+  high-priority.
+- Block deployment/merge when React Doctor, type-check, lint, tests, build,
+  accessibility, performance, or security checks fail.
+- Add TSDoc to new code elements; document API routes and smart-contract
+  surfaces; keep `controllers/` separation and `CREDITS.md` current.
+
+See `docs/QUALITY-STANDARDS.md` for the full specification and the
+post-modification verification checklist.
+
 ## 8. Documentation
 
 Use `src/.claude/skills/update-context/SKILL.md` after repository changes so

--- a/docs/QUALITY-STANDARDS.md
+++ b/docs/QUALITY-STANDARDS.md
@@ -1,0 +1,257 @@
+# Quality Standards
+
+<a id="top"></a>
+
+<!-- docs-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-nav:end -->
+
+## Table of Contents
+
+<!-- docs-toc:start -->
+
+- [1. React Doctor Gate](#1-react-doctor-gate)
+- [2. Deployment and Quality Gates](#2-deployment-and-quality-gates)
+- [3. Performance and Stability](#3-performance-and-stability)
+- [4. UI/UX and Design Consistency](#4-uiux-and-design-consistency)
+- [5. Accessibility](#5-accessibility)
+- [6. Architecture and Project Structure](#6-architecture-and-project-structure)
+- [7. Documentation Standards](#7-documentation-standards)
+- [8. API Documentation](#8-api-documentation)
+- [9. Smart Contract Documentation](#9-smart-contract-documentation)
+- [10. Code Commenting Standards](#10-code-commenting-standards)
+- [11. Verification](#11-verification)
+
+<!-- docs-toc:end -->
+
+**Authors & Contributors:** [Kevin Le](https://www.linkedin.com/in/lekevin1),
+[Kellen Snider](https://www.linkedin.com/in/kellen-snider-683396256/)
+
+Canonical documentation, quality, performance, accessibility, and deployment
+standards for TrustLedger. Every AI guidance file — `CLAUDE.md`, `AGENTS.md`,
+`.codex/AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/*.mdc`,
+Serena, and MCP configuration — must enforce these standards. AI agents must
+validate compliance before completing tasks or approving changes, and must
+proactively identify and resolve violations.
+
+These standards override convenience but not correctness. For trivial tasks,
+apply judgment; never weaken a hard gate (React Doctor, type-check, lint, tests,
+build, security) to ship faster.
+
+---
+
+## 1. React Doctor Gate
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- React Doctor must maintain a score of **100/100** at all times.
+- No pull request, merge, release, deployment, or production promotion may
+  proceed while React Doctor is below 100/100.
+- Treat React Doctor failures, warnings, regressions, anti-patterns, and
+  recommendations as high-priority issues.
+- Whenever code changes, verify the score remains 100/100 and that no new issues
+  were introduced. Proactively identify and resolve anything blocking 100/100.
+- Run with `npm run doctor` from `src/`; see
+  `src/.agents/skills/react-doctor/SKILL.md`.
+
+---
+
+## 2. Deployment and Quality Gates
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+Block any deployment, merge, release, or production promotion when any of these
+fail:
+
+- React Doctor (`npm run doctor`) below 100/100.
+- Type-check (`npx tsc --noEmit`).
+- Lint and format (`npm run lint:frontend`, `prettier --check .`,
+  `forge fmt --check`, `forge lint`).
+- Tests (`forge test`, Hardhat, Jest, Playwright, any others).
+- Build validation (`forge build`, `next build`, any other build step).
+- Accessibility checks, performance audits, and security checks (`security.yml`,
+  Semgrep).
+
+Remove unused code, dead files, stale imports, obsolete assets, duplicate logic,
+and unreachable code whenever you modify a surface. Scope discipline still
+applies: surface unrelated pre-existing dead code instead of deleting it (see
+`CLAUDE.md` §3, root `AGENTS.md` Code Hygiene).
+
+---
+
+## 3. Performance and Stability
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Audit endpoints, API routes, server actions, hooks, components, smart-contract
+  integrations, and background processes for memory leaks, excessive re-renders,
+  blocking operations, and resource spikes.
+- Prevent UI freezes, hangs, hydration errors, race conditions, infinite loops,
+  memory leaks, and excessive CPU or memory consumption.
+- Optimize bundle size, rendering performance, caching, lazy loading, code
+  splitting, database queries, and network requests.
+- Keep external fetches and RPC transports bounded by explicit timeouts; reuse
+  `src/lib/fetchTimeout.ts` or a provider-native timeout.
+- Verify stable performance on desktop, tablet, mobile, and low-resource
+  devices. React Scan (`ReactScanMonitor`) is available in development for
+  regression hunting.
+
+---
+
+## 4. UI/UX and Design Consistency
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Audit gradients, fades, overlays, shadows, animations, transitions, and color
+  systems. Fix abrupt color cutoffs, inconsistent fades, awkward blending,
+  visual artifacts, and styling regressions.
+- Keep analytics pages, legal pages, dashboards, forms, modals, and all routes
+  at consistent visual polish.
+- Verify responsive behavior across every supported breakpoint and device class.
+- Maintain a consistent design system, spacing scale, typography hierarchy, and
+  interaction patterns. Use the `impeccable` skill for interface design and
+  audits.
+
+---
+
+## 5. Accessibility
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Meet WCAG standards where practical.
+- Verify color contrast, focus states, keyboard navigation, ARIA attributes,
+  semantic HTML, reduced-motion support, screen-reader compatibility, and form
+  accessibility.
+- Keep all interactive elements accessible across supported devices and input
+  methods. See `src/.agents/skills/playwright-a11y/SKILL.md` and
+  `src/.agents/agents/accessibility-reviewer.md`.
+
+---
+
+## 6. Architecture and Project Structure
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Maintain a dedicated `controllers/` directory for business-logic separation.
+- Maintain a `CREDITS.md` file documenting contributors, libraries, frameworks,
+  assets, inspirations, and acknowledgements.
+- Enforce clear separation of concerns between UI, services, controllers, API
+  routes, contracts, hooks, utilities, and data layers.
+
+---
+
+## 7. Documentation Standards
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Add comprehensive TSDoc to all functions, classes, interfaces, types, hooks,
+  utilities, services, controllers, modules, and public APIs.
+- Document parameters, return values, exceptions, side effects, examples, and
+  usage notes where applicable.
+- Keep documentation synchronized with implementation changes in the same PR
+  (see `CLAUDE.md` §8).
+
+---
+
+## 8. API Documentation
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Document every API route, endpoint, server action, webhook, middleware,
+  request schema, response schema, authentication requirement, validation rule,
+  error response, rate limit, and integration flow.
+- Maintain accurate OpenAPI/Swagger documentation where applicable.
+
+---
+
+## 9. Smart Contract Documentation
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Fully document contracts, inheritance trees, libraries, interfaces, structs,
+  enums, constants, state variables, modifiers, events, custom errors, storage
+  layouts, permissions, access controls, and functions.
+- Document emitted events, error conditions, state transitions, security
+  assumptions, trust boundaries, external integrations, and intended usage
+  patterns.
+- Explain business logic, economic assumptions, and security considerations for
+  each contract component. See `docs/SMART-CONTRACTS.md`.
+
+---
+
+## 10. Code Commenting Standards
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+- Add meaningful comments where they improve maintainability or explain
+  non-obvious behavior.
+- Avoid redundant comments that merely restate code.
+- Prioritize clarity, maintainability, onboarding efficiency, and long-term
+  sustainability.
+
+---
+
+## 11. Verification
+
+<!-- docs-section-nav:start -->
+
+[Home](Home.md) · [Top](#top) · [Table of Contents](#table-of-contents)
+
+<!-- docs-section-nav:end -->
+
+After modifications, validate and report on:
+
+- React Doctor = 100/100
+- Build succeeds
+- Type-check passes
+- Lint passes
+- Tests pass
+- Accessibility checks pass
+- Mobile responsiveness passes
+- No memory spikes, freezes, regressions, warnings, or documentation gaps
+
+Run targeted checks first, then broad gates (see root `AGENTS.md` Runner
+Discipline). Report outcomes faithfully: if a check fails or was skipped, say so
+with the evidence.


### PR DESCRIPTION
## Summary
- Add `docs/QUALITY-STANDARDS.md` as the canonical documentation, quality, performance, accessibility, and deployment specification (11 sections + verification checklist).
- Reference and enforce it from every AI guidance surface so all agents validate compliance before completing tasks.

## Files wired to the canonical spec
- `AGENTS.md` — new **Quality Standards (Mandatory)** section (canonical hub, precedence #2).
- `CLAUDE.md` — new §7.1.
- `.codex/AGENTS.md` — Required Routing entry.
- `.github/copilot-instructions.md` — enforcement paragraph.
- `.cursor/instructions/precedence.md` — compliance note.
- `.cursor/rules/frontend.mdc` — React Doctor / a11y / performance gate.
- `.cursor/rules/docs.mdc` — documentation standards.
- `.serena/memories/quality_standards.md` — dense Serena-style memory.

## Notes
- Architecture follows the repo's existing layered, reference-style model (one canonical doc + thin pointers) rather than duplicating the spec into each file.
- MCP config files are JSON server definitions and inherit the chain via `AGENTS.md`; left untouched.
- Scope was instruction-files only. The spec names a `controllers/` directory and `CREDITS.md` that don't exist yet — now documented as required, not yet scaffolded.

## Verification
- markdownlint: 0 errors across all changed files.
- Pre-commit hooks (gitleaks, docs nav, prettier, markdownlint, tests) green; 126 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)