### PR TITLE
style: standardize transition easing, shine-sweep, and analytics badge

### DIFF
--- a/src/app/[locale]/analytics/_components/AnalyticsPageInner.tsx
+++ b/src/app/[locale]/analytics/_components/AnalyticsPageInner.tsx
@@ -412,7 +412,7 @@ export function AnalyticsPageInner(): React.JSX.Element {
 								{t("statusBody")}
 							</p>
 						</div>
-						<span className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-800 shadow-sm shadow-cyan-950/5 dark:border-cyan-300/30 dark:bg-cyan-300/15 dark:text-cyan-100">
+						<span className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 text-xs font-semibold text-cyan-800 dark:border-cyan-300/30 dark:bg-cyan-300/15 dark:text-cyan-100">
 							{t("publicOnly")}
 						</span>
 					</div>

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -54,6 +54,10 @@ html.dark {
 $tl-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
 $tl-ease-standard: cubic-bezier(0.2, 0, 0, 1);
 
+/* Shared highlight for the diagonal "shine sweep" used on buttons, bars, and
+   guide cards. One token keeps the sweep brightness consistent app-wide. */
+$tl-sweep-highlight: rgb(255 255 255 / 26%);
+
 @keyframes tl-soft-float {
 	0%,
 	100% {
@@ -274,7 +278,7 @@ $tl-ease-standard: cubic-bezier(0.2, 0, 0, 1);
 		position: absolute;
 		inset: 0;
 		transform: translateX(-105%);
-		background: linear-gradient(90deg, transparent, rgb(255 255 255 / 22%), transparent);
+		background: linear-gradient(90deg, transparent, $tl-sweep-highlight, transparent);
 		content: "";
 		transition: transform 520ms $tl-ease-out;
 	}
@@ -409,7 +413,7 @@ $tl-ease-standard: cubic-bezier(0.2, 0, 0, 1);
 .tl-guide-task::after {
 	position: absolute;
 	inset: 0;
-	background: linear-gradient(90deg, transparent, rgb(255 255 255 / 35%), transparent);
+	background: linear-gradient(90deg, transparent, $tl-sweep-highlight, transparent);
 	opacity: 0;
 	content: "";
 	transform: translateX(-120%);
@@ -534,7 +538,7 @@ $tl-ease-standard: cubic-bezier(0.2, 0, 0, 1);
 .tl-analytics-bar::after {
 	position: absolute;
 	inset: 0;
-	background: linear-gradient(90deg, transparent, rgb(255 255 255 / 28%), transparent);
+	background: linear-gradient(90deg, transparent, $tl-sweep-highlight, transparent);
 	content: "";
 	transform: translateX(-100%);
 	transition: transform 520ms $tl-ease-out;
@@ -721,10 +725,10 @@ details[open] .tl-faq-answer {
 	padding: 0.5rem 0.875rem;
 	box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%);
 	transition:
-		background-color 150ms ease,
-		border-color 150ms ease,
-		color 150ms ease,
-		box-shadow 150ms ease;
+		background-color 150ms $tl-ease-standard,
+		border-color 150ms $tl-ease-standard,
+		color 150ms $tl-ease-standard,
+		box-shadow 150ms $tl-ease-standard;
 
 	&:focus-visible {
 		outline: 2px solid #6366f1;
@@ -767,7 +771,7 @@ details[open] .tl-faq-answer {
 	pointer-events: none;
 	flex-shrink: 0;
 	color: #6b7280;
-	transition: transform 150ms ease;
+	transition: transform 150ms $tl-ease-out;
 }
 
 .locale-switcher__button[aria-expanded="true"] .locale-switcher__chevron {
@@ -804,8 +808,8 @@ details[open] .tl-faq-answer {
 	font-size: 0.875rem;
 	font-weight: 500;
 	transition:
-		background-color 150ms ease,
-		color 150ms ease;
+		background-color 150ms $tl-ease-standard,
+		color 150ms $tl-ease-standard;
 }
 
 .locale-switcher__option:hover,
@@ -910,9 +914,9 @@ details[open] .tl-faq-answer {
 	text-align: start;
 	box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%);
 	transition:
-		border-color 150ms ease,
-		background-color 150ms ease,
-		box-shadow 150ms ease;
+		border-color 150ms $tl-ease-standard,
+		background-color 150ms $tl-ease-standard,
+		box-shadow 150ms $tl-ease-standard;
 
 	&:hover {
 		border-color: #d1d5db;
@@ -954,7 +958,7 @@ details[open] .tl-faq-answer {
 	color: #6366f1;
 	font-size: 1.1rem;
 	line-height: 1;
-	transition: transform 150ms ease;
+	transition: transform 150ms $tl-ease-out;
 }
 
 .tl-choice-menu__button[aria-expanded="true"] .tl-choice-menu__chevron {
@@ -988,8 +992,8 @@ details[open] .tl-faq-answer {
 	padding: 0.5rem 0.625rem;
 	text-align: start;
 	transition:
-		background-color 150ms ease,
-		color 150ms ease;
+		background-color 150ms $tl-ease-standard,
+		color 150ms $tl-ease-standard;
 
 	&:hover,
 	&:focus-visible {
@@ -1015,11 +1019,11 @@ details[open] .tl-faq-answer {
 
 .tl-editor-tool {
 	transition:
-		background-color 150ms ease,
-		border-color 150ms ease,
-		color 150ms ease,
-		box-shadow 150ms ease,
-		transform 150ms ease;
+		background-color 150ms $tl-ease-standard,
+		border-color 150ms $tl-ease-standard,
+		color 150ms $tl-ease-standard,
+		box-shadow 150ms $tl-ease-standard,
+		transform 150ms $tl-ease-out;
 
 	&:hover {
 		box-shadow: 0 0 0 3px rgb(99 102 241 / 9%);


### PR DESCRIPTION
- Route locale-switcher, choice-menu, and editor-tool transitions through
  the shared $tl-ease-standard / $tl-ease-out tokens (was raw 150ms ease)
- Add $tl-sweep-highlight token; unify button/bar/guide shine sweeps at 26%
- Drop lone shadow on the analytics "Public Only" badge to match its sibling

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
